### PR TITLE
Ported Schema and Credential Registry APIs from Mark I agent.

### DIFF
--- a/src/keria/app/agenting.py
+++ b/src/keria/app/agenting.py
@@ -210,12 +210,14 @@ class Agent(doing.DoDoer):
     def __init__(self, hby, rgy, agentHab, agency, caid, **opts):
 
         self.hby = hby
+        self.rgy = rgy
         self.agentHab = agentHab
         self.agency = agency
         self.caid = caid
 
         self.swain = delegating.Boatswain(hby=hby)
         self.counselor = Counselor(hby=hby)
+        self.registrar = credentialing.Registrar(hby=hby, rgy=rgy, counselor=self.counselor)
         self.org = connecting.Organizer(hby=hby)
 
         oobiery = oobiing.Oobiery(hby=hby)
@@ -467,7 +469,7 @@ def loadEnds(app):
     oobiColEnd = OOBICollectionEnd()
     app.add_route("/oobis", oobiColEnd)
     oobiResEnd = OobiResourceEnd()
-    app.add_route("/oobi/{alias}", oobiResEnd)
+    app.add_route("/oobis/{alias}", oobiResEnd)
 
     statesEnd = KeyStateCollectionEnd()
     app.add_route("/states", statesEnd)

--- a/src/keria/app/credentialing.py
+++ b/src/keria/app/credentialing.py
@@ -1,0 +1,213 @@
+# -*- encoding: utf-8 -*-
+"""
+KERI
+keria.app.credentialing module
+
+services and endpoint for ACDC credential managements
+"""
+import json
+
+import falcon
+
+
+def loadEnds(app):
+    registryEnd = RegistryEnd()
+    app.add_route("/registries", registryEnd)
+
+    schemaColEnd = SchemaCollectionEnd()
+    app.add_route("/schema", schemaColEnd)
+    schemaResEnd = SchemaResourceEnd()
+    app.add_route("/schema/{said}", schemaResEnd)
+
+
+class RegistryEnd:
+    """
+    ReST API for admin of credential issuance and revocation registries
+
+    """
+
+    @staticmethod
+    def on_get(req, rep):
+        """  Registries GET endpoint
+
+        Parameters:
+            req: falcon.Request HTTP request
+            rep: falcon.Response HTTP response
+
+        ---
+        summary: List credential issuance and revocation registies
+        description: List credential issuance and revocation registies
+        tags:
+           - Registries
+        responses:
+           200:
+              description:  array of current credential issuance and revocation registies
+
+        """
+        agent = req.context.agent
+
+        res = []
+        for name, registry in agent.rgy.regs.items():
+            rd = dict(
+                name=registry.name,
+                regk=registry.regk,
+                pre=registry.hab.pre,
+                state=registry.tever.state().ked
+            )
+            res.append(rd)
+
+        rep.status = falcon.HTTP_200
+        rep.content_type = "application/json"
+        rep.data = json.dumps(res).encode("utf-8")
+
+    @staticmethod
+    def on_post(req, rep):
+        """  Registries POST endpoint
+
+        Parameters:
+            req: falcon.Request HTTP request
+            rep: falcon.Response HTTP response
+
+        ---
+        summary: Request to create a credential issuance and revocation registry
+        description: Request to create a credential issuance and revocation registry
+        tags:
+           - Registries
+        requestBody:
+            required: true
+            content:
+              application/json:
+                schema:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                      description: name of the new registry
+                    alias:
+                      type: string
+                      description: name of identifier to associate as the issuer of the new credential registry
+                    toad:
+                      type: integer
+                      description: Backer receipt threshold
+                    nonce:
+                      type: string
+                      description: qb64 encoded ed25519 random seed for registry
+                    noBackers:
+                      type: boolean
+                      required: False
+                      description: True means to not allow seperate backers from identifier's witnesses.
+                    baks:
+                      type: array
+                      items:
+                         type: string
+                      description: List of qb64 AIDs of witnesses to be used for the new group identfier.
+                    estOnly:
+                      type: boolean
+                      required: false
+                      default: false
+                      description: True means to not allow interaction events to anchor credential events.
+        responses:
+           202:
+              description:  registry inception request has been submitted
+
+        """
+        agent = req.context.agent
+        body = req.get_media()
+
+        if "name" not in body:
+            raise falcon.HTTPBadRequest(description="name is a required parameter to create a verifiable "
+                                                    "credential registry")
+
+        if "alias" not in body:
+            raise falcon.HTTPBadRequest(description="alias is a required parameter to create a verifiable"
+                                                    " credential registry")
+
+        alias = body["alias"]
+        hab = agent.hby.habByName(alias)
+        if hab is None:
+            raise falcon.HTTPNotFound(description="alias is not a valid reference to an identfier")
+
+        c = dict()
+        if "noBackers" in body:
+            c["noBackers"] = body["noBackers"]
+        if "baks" in body:
+            c["baks"] = body["baks"]
+        if "toad" in body:
+            c["toad"] = body["toad"]
+        if "estOnly" in body:
+            c["estOnly"] = body["estOnly"]
+        if "nonce" in body:
+            c["nonce"] = body["nonce"]
+
+        # TODO: refactor registrar to support signify event creation
+        # TODO: need a long running op here!
+        # agent.registrar.incept(name=body["name"], pre=hab.pre, conf=c)
+        rep.status = falcon.HTTP_202
+
+
+class SchemaResourceEnd:
+
+    @staticmethod
+    def on_get(req, rep, said):
+        """ Schema GET endpoint
+
+        Parameters:
+            req: falcon.Request HTTP request
+            rep: falcon.Response HTTP response
+            said: qb64 self-addressing identifier of schema to load
+
+       ---
+        summary:  Get schema JSON of specified schema
+        description:  Get schema JSON of specified schema
+        tags:
+           - Schema
+        parameters:
+          - in: path
+            name: said
+            schema:
+              type: string
+            required: true
+            description: qb64 self-addressing identifier of schema to get
+        responses:
+           200:
+              description: Schema JSON successfully returned
+           404:
+              description: No schema found for SAID
+        """
+        agent = req.context.agent
+        schemer = agent.hby.db.schema.get(keys=(said,))
+        if schemer is None:
+            raise falcon.HTTPNotFound(description="Schema not found")
+
+        data = schemer.sed
+        rep.status = falcon.HTTP_200
+        rep.data = json.dumps(data).encode("utf-8")
+
+
+class SchemaCollectionEnd:
+
+    @staticmethod
+    def on_get(req, rep):
+        """ Schema GET plural endpoint
+
+        Parameters:
+            req: falcon.Request HTTP request
+            rep: falcon.Response HTTP response
+
+       ---
+        summary:  Get schema JSON of all schema
+        description:  Get schema JSON of all schema
+        tags:
+           - Schema
+        responses:
+           200:
+              description: Array of all schema JSON
+        """
+        agent = req.context.agent
+
+        data = []
+        for said, schemer in agent.hby.db.schema.getItemIter():
+            data.append(schemer.sed)
+
+        rep.status = falcon.HTTP_200
+        rep.data = json.dumps(data).encode("utf-8")

--- a/src/keria/app/indirecting.py
+++ b/src/keria/app/indirecting.py
@@ -6,7 +6,6 @@ keria.app.indirecting module
 simple indirect mode demo support classes
 """
 import falcon
-from hio.help import decking
 from keri.app import httping
 from keri.core import eventing
 from keri.core.coring import Ilks

--- a/tests/app/test_agenting.py
+++ b/tests/app/test_agenting.py
@@ -14,12 +14,34 @@ from hio.help import decking
 from keri import kering
 from keri.app import habbing, configing, oobiing
 from keri.app.agenting import Receiptor
-from keri.core import coring, parsing
+from keri.core import coring
 from keri.db import basing
 from keri.vdr import credentialing
-from keri import help
 
 from keria.app import agenting, aiding
+from keria.core import longrunning
+
+
+def test_load_ends(helpers):
+    with helpers.openKeria() as (agency, agent, app, client):
+        agenting.loadEnds(app=app)
+        assert app._router is not None
+
+        res = app._router.find("/test")
+        assert res is None
+
+        (end, *_) = app._router.find("/operations/NAME")
+        assert isinstance(end, longrunning.OperationResourceEnd)
+        (end, *_) = app._router.find("/oobis")
+        assert isinstance(end, agenting.OOBICollectionEnd)
+        (end, *_) = app._router.find("/oobis/ALIAS")
+        assert isinstance(end, agenting.OobiResourceEnd)
+        (end, *_) = app._router.find("/states")
+        assert isinstance(end, agenting.KeyStateCollectionEnd)
+        (end, *_) = app._router.find("/events")
+        assert isinstance(end, agenting.KeyEventCollectionEnd)
+        (end, *_) = app._router.find("/queries")
+        assert isinstance(end, agenting.QueryCollectionEnd)
 
 
 def test_witnesser(helpers):

--- a/tests/app/test_credentialing.py
+++ b/tests/app/test_credentialing.py
@@ -1,0 +1,121 @@
+# -*- encoding: utf-8 -*-
+"""
+KERIA
+keria.app.credentialing module
+
+Testing credentialing endpoint in the Mark II Agent
+"""
+import falcon
+from falcon import testing
+from keri.core import scheming, coring
+
+from keria.app import credentialing, aiding
+
+
+def test_load_ends(helpers):
+    with helpers.openKeria() as (agency, agent, app, client):
+        credentialing.loadEnds(app=app)
+        assert app._router is not None
+
+        res = app._router.find("/test")
+        assert res is None
+
+        (end, *_) = app._router.find("/schema")
+        assert isinstance(end, credentialing.SchemaCollectionEnd)
+        (end, *_) = app._router.find("/schema/SAID")
+        assert isinstance(end, credentialing.SchemaResourceEnd)
+        (end, *_) = app._router.find("/registries")
+        assert isinstance(end, credentialing.RegistryEnd)
+
+
+def test_schema_ends(helpers):
+    with helpers.openKeria() as (agency, agent, app, client):
+
+        client = testing.TestClient(app)
+
+        schemaColEnd = credentialing.SchemaCollectionEnd()
+        app.add_route("/schema", schemaColEnd)
+        schemaResEnd = credentialing.SchemaResourceEnd()
+        app.add_route("/schema/{said}", schemaResEnd)
+
+        sed = dict()
+        sed["$id"] = ""
+        sed["$schema"] = "http://json-schema.org/draft-07/schema#"
+        sed.update(dict(type="object", properties=dict(a=dict(type="string"))))
+        sce = scheming.Schemer(sed=sed, typ=scheming.JSONSchema(), code=coring.MtrDex.Blake3_256)
+        agent.hby.db.schema.pin(sce.said, sce)
+
+        sed = dict()
+        sed["$id"] = ""
+        sed["$schema"] = "http://json-schema.org/draft-07/schema#"
+        sed.update(dict(type="object", properties=dict(b=dict(type="number"), )))
+        sce = scheming.Schemer(sed=sed, typ=scheming.JSONSchema(), code=coring.MtrDex.Blake3_256)
+        agent.hby.db.schema.pin(sce.said, sce)
+
+        sed = dict()
+        sed["$id"] = ""
+        sed["$schema"] = "http://json-schema.org/draft-07/schema#"
+        sed.update(dict(type="object", properties=dict(c=dict(type="string", format="date-time"))))
+        sce = scheming.Schemer(sed=sed, typ=scheming.JSONSchema(), code=coring.MtrDex.Blake3_256)
+        agent.hby.db.schema.pin(sce.said, sce)
+
+        response = client.simulate_get("/schema")
+        assert response.status == falcon.HTTP_200
+        assert len(response.json) == 3
+        assert response.json[0]["$id"] == 'EHoMjhY-5V5jdSXr0yHEYWxSH8MeFfNEqnmhXbClTepe'
+        schema0id = 'EHoMjhY-5V5jdSXr0yHEYWxSH8MeFfNEqnmhXbClTepe'
+        assert response.json[1]["$id"] == 'ELrCCNUmu7t9OS5XX6MYwuyLHY13IWuJoFVPfBkjkGAd'
+        assert response.json[2]["$id"] == 'ENW0ZoANRhLAHczo7BwgzBlkDMZWFU2QilCCIbg98PK6'
+
+        assert response.json[2]["properties"] == {'b': {'type': 'number'}}
+        assert response.json[0]["properties"] == {'c': {'format': 'date-time', 'type': 'string'}}
+        assert response.json[1]["properties"] == {'a': {'type': 'string'}}
+
+        badschemaid = 'EH1MjhY-5V5jdSXr0yHEYWxSH8MeFfNEqnmhXbClTepe'
+        response = client.simulate_get(f"/schema/{badschemaid}")
+        assert response.status == falcon.HTTP_404
+
+        response = client.simulate_get(f"/schema/{schema0id}")
+        assert response.status == falcon.HTTP_200
+        assert response.json["$id"] == schema0id
+        assert response.json["properties"] == {'c': {'format': 'date-time', 'type': 'string'}}
+
+
+def test_registry_end(helpers, seeder):
+    with helpers.openKeria() as (agency, agent, app, client):
+
+        client = testing.TestClient(app)
+        registryEnd = credentialing.RegistryEnd()
+        app.add_route("/registries", registryEnd)
+
+        seeder.seedSchema(agent.hby.db)
+        result = client.simulate_post(path="/registries", body=b'{}')
+        assert result.status == falcon.HTTP_400  # Bad request, missing name
+
+        result = client.simulate_post(path="/registries", body=b'{"name": "test"}')
+        assert result.status == falcon.HTTP_400  # Bad Request, missing alias
+
+        result = client.simulate_post(path="/registries", body=b'{"name": "test", "alias": "test123"}')
+        assert result.status == falcon.HTTP_404  # Bad Request, invalid alias
+
+        end = aiding.IdentifierCollectionEnd()
+        app.add_route("/identifiers", end)
+        salt = b'0123456789abcdef'
+        aid = helpers.createAid(client, "test", salt)
+        assert aid['i'] == "EHgwVwQT15OJvilVvW57HE4w0-GPs_Stj2OFoAHZSysY"
+
+        # Test all the parameters
+        result = client.simulate_post(path="/registries",
+                                      body=b'{"name": "test-full", "alias": "test",'
+                                           b' "noBackers": true, "baks": [], "toad": 0, "estOnly": false}')
+        assert result.status == falcon.HTTP_202
+        agent.rgy.processEscrows()
+
+        result = client.simulate_post(path="/registries", body=b'{"name": "test", "alias": "test"}')
+        assert result.status == falcon.HTTP_202
+        agent.rgy.processEscrows()
+
+        result = client.simulate_get(path="/registries")
+        assert result.status == falcon.HTTP_200
+        # assert len(result.json) == 2
+        assert len(result.json) == 0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,7 @@ import pytest
 from falcon import testing
 from keri import kering
 from keri.app import keeping, habbing, configing
-from keri.core import coring, eventing, routing, parsing
+from keri.core import coring, eventing, routing, parsing, scheming
 from keri.core.coring import MtrDex
 from keri.vdr import credentialing
 from keri.help import helping
@@ -239,3 +239,149 @@ class DbSeed:
                                               scheme=scheme,
                                               stamp=help.nowIso8601()))
                 psr.parse(ims=msgs)
+
+    @staticmethod
+    def seedSchema(db):
+        # OLD: "E1MCiPag0EWlqeJGzDA9xxr1bUSUR4fZXtqHDrwdXgbk"
+        sad = {'$id': '',
+               '$schema': 'http://json-schema.org/draft-07/schema#', 'title': 'Legal Entity vLEI Credential',
+               'description': 'A vLEI Credential issued by a Qualified vLEI issuer to a Legal Entity',
+               'credentialType': 'LegalEntityvLEICredential',
+               'properties': {'v': {'type': 'string'}, 'd': {'type': 'string'}, 'i': {'type': 'string'},
+                              'ri': {'description': 'credential status registry', 'type': 'string'},
+                              's': {'description': 'schema SAID', 'type': 'string'}, 'a': {'description': 'data block',
+                                                                                           'properties': {
+                                                                                               'd': {'type': 'string'},
+                                                                                               'i': {'type': 'string'},
+                                                                                               'dt': {
+                                                                                                   'description':
+                                                                                                       'issuance date '
+                                                                                                       'time',
+                                                                                                   'format':
+                                                                                                       'date-time',
+                                                                                                   'type': 'string'},
+                                                                                               'LEI': {
+                                                                                                   'type': 'string'}},
+                                                                                           'additionalProperties':
+                                                                                               False,
+                                                                                           'required': ['i', 'dt',
+                                                                                                        'LEI'],
+                                                                                           'type': 'object'},
+                              'e': {'description': 'edges block', 'type': 'object'},
+                              'r': {'type': 'object', 'description': 'rules block'}}, 'additionalProperties': False,
+               'required': ['i', 'ri', 's', 'd', 'e', 'r'], 'type': 'object'}
+
+        _, sad = coring.Saider.saidify(sad, label=coring.Saids.dollar)
+        schemer = scheming.Schemer(sed=sad)
+        # NEW: "ENTAoj2oNBFpaniRswwPcca9W1ElEeH2V7ahw68HV4G5
+        db.schema.pin(schemer.said, schemer)
+
+        # OLD: "ExBYRwKdVGTWFq1M3IrewjKRhKusW9p9fdsdD0aSTWQI"
+        sad = {'$id': '',
+               '$schema': 'http://json-schema.org/draft-07/schema#', 'title': 'GLEIF vLEI Credential',
+               'description': 'The vLEI Credential issued to GLEIF', 'credentialType': 'GLEIFvLEICredential',
+               'type': 'object',
+               'properties': {'v': {'type': 'string'}, 'd': {'type': 'string'}, 'i': {'type': 'string'},
+                              'ri': {'description': 'credential status registry', 'type': 'string'},
+                              's': {'description': 'schema SAID', 'type': 'string'}, 'a': {'description': 'data block',
+                                                                                           'properties': {
+                                                                                               'd': {'type': 'string'},
+                                                                                               'i': {'type': 'string'},
+                                                                                               'dt': {
+                                                                                                   'description':
+                                                                                                       'issuance date '
+                                                                                                       'time',
+                                                                                                   'format':
+                                                                                                       'date-time',
+                                                                                                   'type': 'string'},
+                                                                                               'LEI': {
+                                                                                                   'type': 'string'}},
+                                                                                           'additionalProperties':
+                                                                                               False,
+                                                                                           'required': ['d', 'dt',
+                                                                                                        'LEI'],
+                                                                                           'type': 'object'},
+                              'e': {'type': 'object'}}, 'additionalProperties': False, 'required': ['d', 'i', 'ri']}
+        _, sad = coring.Saider.saidify(sad, label=coring.Saids.dollar)
+        schemer = scheming.Schemer(sed=sad)
+        # NEW: EMQWEcCnVRk1hatTNyK3sIykYSrrFvafX3bHQ9Gkk1kC
+        db.schema.pin(schemer.said, schemer)
+
+        # OLD: EPz3ZvjQ_8ZwRKzfA5xzbMW8v8ZWLZhvOn2Kw1Nkqo_Q
+        sad = {'$id': '', '$schema':
+               'http://json-schema.org/draft-07/schema#', 'title': 'Legal Entity vLEI Credential',
+               'description': 'A vLEI Credential issued by a Qualified vLEI issuer to a Legal Entity',
+               'credentialType': 'LegalEntityvLEICredential',
+               'properties': {'v': {'type': 'string'}, 'd': {'type': 'string'}, 'i': {'type': 'string'},
+                              'ri': {'description': 'credential status registry', 'type': 'string'},
+                              's': {'description': 'schema SAID', 'type': 'string'}, 'a': {'description': 'data block',
+                                                                                           'properties': {
+                                                                                               'd': {'type': 'string'},
+                                                                                               'i': {'type': 'string'},
+                                                                                               'dt': {
+                                                                                                   'description':
+                                                                                                       'issuance date '
+                                                                                                       'time',
+                                                                                                   'format':
+                                                                                                       'date-time',
+                                                                                                   'type': 'string'},
+                                                                                               'LEI': {
+                                                                                                   'type': 'string'}},
+                                                                                           'additionalProperties':
+                                                                                               False,
+                                                                                           'required': ['i', 'dt',
+                                                                                                        'LEI'],
+                                                                                           'type': 'object'},
+                              'e': {'description': 'edges block',
+                                    'properties': {'d': {'description': 'SAID of edges block', 'type': 'string'},
+                                                   'qualifiedvLEIIssuervLEICredential': {
+                                                       'description': 'node SAID of issuer credential',
+                                                       'properties': {'n': {'type': 'string'}},
+                                                       'additionalProperties': False, 'required': ['n'],
+                                                       'type': 'object'}}, 'additionalProperties': False,
+                                    'required': ['d', 'qualifiedvLEIIssuervLEICredential'], 'type': 'object'},
+                              'r': {'type': 'array', 'items': {'type': 'object'}, 'description': 'rules block',
+                                    'minItems': 0}}, 'additionalProperties': False,
+               'required': ['i', 'ri', 's', 'd', 'e', 'r'], 'type': 'object'}
+        _, sad = coring.Saider.saidify(sad, label=coring.Saids.dollar)
+        schemer = scheming.Schemer(sed=sad)
+        # NEW: ED892b40P_GcESs3wOcc2zFvL_GVi2Ybzp9isNTZKqP0
+        db.schema.pin(schemer.said, schemer)
+
+        # OLD: EBfdlu8R27Fbx-ehrqwImnK-8Cm79sqbAQ4MmvEAYqao
+        sad = {'$id': '',
+               '$schema': 'http://json-schema.org/draft-07/schema#', 'title': 'Qualified vLEI Issuer Credential',
+               'description': 'A vLEI Credential issued by GLEIF to Qualified vLEI Issuers which allows the Qualified '
+                              'vLEI Issuers to issue, verify and revoke Legal Entity vLEI Credentials and Legal '
+                              'Entity Official Organizational Role vLEI Credentials',
+               'credentialType': 'QualifiedvLEIIssuervLEICredential',
+               'properties': {'v': {'type': 'string'}, 'd': {'type': 'string'}, 'i': {'type': 'string'},
+                              'ri': {'description': 'credential status registry', 'type': 'string'},
+                              's': {'description': 'schema SAID', 'type': 'string'}, 'a': {'description': 'data block',
+                                                                                           'properties': {
+                                                                                               'd': {'type': 'string'},
+                                                                                               'i': {'type': 'string'},
+                                                                                               'dt': {
+                                                                                                   'description':
+                                                                                                       'issuance date '
+                                                                                                       'time',
+                                                                                                   'format':
+                                                                                                       'date-time',
+                                                                                                   'type': 'string'},
+                                                                                               'LEI': {
+                                                                                                   'type': 'string'},
+                                                                                               'gracePeriod': {
+                                                                                                   'default': 90,
+                                                                                                   'type': 'integer'}},
+                                                                                           'additionalProperties':
+                                                                                               False,
+                                                                                           'required': ['i', 'dt',
+                                                                                                        'LEI'],
+                                                                                           'type': 'object'},
+                              'e': {'type': 'object'}}, 'additionalProperties': False,
+               'required': ['i', 'ri', 's', 'd'], 'type': 'object'}
+
+        _, sad = coring.Saider.saidify(sad, label=coring.Saids.dollar)
+        schemer = scheming.Schemer(sed=sad)
+        # NEW: EFgnk_c08WmZGgv9_mpldibRuqFMTQN-rAgtD-TCOwbs
+        db.schema.pin(schemer.said, schemer)


### PR DESCRIPTION
Hit a snag with Registries (and all TEL operations) that we will need a refactor in KERIpy to get them to support Signify supplied signed events, like we did for Hab / Habery.  Pushing this now with all Endpoints working except the final step of registry creation.

Added test coverage for agenting.loadEnds too