### PR TITLE
CI for docker publish

### DIFF
--- a/.github/workflows/publish-keria.yml
+++ b/.github/workflows/publish-keria.yml
@@ -1,0 +1,38 @@
+
+name: Publish Docker image
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        required: true
+jobs:
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: WebOfTrust/keria
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: images/keria.dockerfile
+          push: true
+          tags: |
+            WebOfTrust/keria:${{ github.event.inputs.version }}
+            WebOfTrust/keria:latest
+          labels: ${{ github.event.inputs.version }}


### PR DESCRIPTION
This PR includes GitHub action workflow for publishing the KERIA docker image to WebOfTrust on Docker Hub