### PR TITLE
Initial stubs added for external HSM key management support

### DIFF
--- a/src/keria/app/agenting.py
+++ b/src/keria/app/agenting.py
@@ -301,6 +301,12 @@ class Agent(doing.DoDoer):
 
         self.agency.incept(self.caid, pre)
 
+    def inceptExtern(self, pre, verfers, digers, **kwargs):
+        keeper = self.remoteMgr.get(Algos.extern)
+        keeper.incept(pre=pre, verfers=verfers, digers=digers, **kwargs)
+
+        self.agency.incept(self.caid, pre)
+
 
 class Messager(doing.Doer):
 

--- a/src/keria/app/aiding.py
+++ b/src/keria/app/aiding.py
@@ -195,6 +195,15 @@ class IdentifierCollectionEnd:
                         agent.hby.deleteHab(name=name)
                         raise falcon.HTTPInternalServerError(description=f"{e.args[0]}")
 
+                elif Algos.extern in body:
+                    extern = body[Algos.extern]
+                    hab = agent.hby.makeSignifyHab(name, serder=serder, sigers=sigers)
+                    try:
+                        agent.inceptExtern(pre=serder.pre, verfers=serder.verfers, digers=serder.digers, **extern)
+                    except ValueError as e:
+                        agent.hby.deleteHab(name=name)
+                        raise falcon.HTTPInternalServerError(description=f"{e.args[0]}")
+
                 else:
                     raise falcon.HTTPBadRequest(
                         description="invalid request: one of group, rand or salt field required")

--- a/src/keria/core/keeping.py
+++ b/src/keria/core/keeping.py
@@ -383,3 +383,6 @@ class ExternKeeper:
 
     def __init__(self, rb: RemoteKeeper):
         self.rb = rb
+
+    def incept(self, **kwargs):
+        pass

--- a/tests/app/test_aiding.py
+++ b/tests/app/test_aiding.py
@@ -465,6 +465,29 @@ def test_identifier_collection_end(helpers):
         op = helpers.createAid(client, "delegatee", salt, delpre=delpre)
         assert op['name'] == "delegation.EFt8G8gkCJ71e4amQaRUYss0BDK4pUpzKelEIr3yZ1D0"
 
+    # Test extern keys for HSM integration, only initial tests, work still needed
+    with helpers.openKeria() as (agency, agent, app, client):
+        end = aiding.IdentifierCollectionEnd()
+        resend = aiding.IdentifierResourceEnd()
+        app.add_route("/identifiers", end)
+        app.add_route("/identifiers/{name}", resend)
+
+        client = testing.TestClient(app)
+
+        # Test with randy
+        serder, signers = helpers.inceptExtern(count=1)
+        sigers = [signer.sign(ser=serder.raw, index=0).qb64 for signer in signers]
+
+        body = {'name': 'randy1',
+                'icp': serder.ked,
+                'sigs': sigers,
+                'extern': {
+                    "stem": "test-fake-stem",
+                    "transferable": True,
+                }
+                }
+        res = client.simulate_post(path="/identifiers", body=json.dumps(body))
+        assert res.status_code == 200
 
 def test_challenge_ends(helpers):
     with helpers.openKeria() as (agency, agent, app, client):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -164,6 +164,28 @@ class Helpers:
         return serder, signers, prxs, nxts
 
     @staticmethod
+    def inceptExtern(count=1, sith="1", wits=None, toad="0"):
+        if wits is None:
+            wits = []
+
+        creator = keeping.RandyCreator()
+        signers = creator.create(count=count)
+        nsigners = creator.create(count=count)
+
+        keys = [signer.verfer.qb64 for signer in signers]
+        ndigs = [coring.Diger(ser=nsigner.verfer.qb64b) for nsigner in nsigners]
+
+        serder = eventing.incept(keys=keys,
+                                 isith=sith,
+                                 nsith=sith,
+                                 ndigs=[diger.qb64 for diger in ndigs],
+                                 code=coring.MtrDex.Blake3_256,
+                                 toad=toad,
+                                 wits=wits)
+
+        return serder, signers
+
+    @staticmethod
     def createAid(client, name, salt, wits=None, toad="0", delpre=None):
         serder, signers = Helpers.incept(salt, "signify:aid", pidx=0, wits=wits, toad=toad, delpre=delpre)
         assert len(signers) == 1


### PR DESCRIPTION
This PR includes an initial pass at code to support external key managers being used in a signify client.