### PR TITLE
Catching "Already Incepted" error

### DIFF
--- a/src/keria/app/agenting.py
+++ b/src/keria/app/agenting.py
@@ -543,7 +543,11 @@ class BootEnd:
 
         caid = icp.pre
 
-        agent = self.agency.create(caid=caid)
+        try:
+            agent = self.agency.create(caid=caid)
+        except Exception as exc:
+            raise falcon.HTTPBadRequest(title=f'{exc}',
+                                        description=f'{exc}')
 
         try:
             ctrlHab = agent.hby.makeSignifyHab(name=agent.caid, ns="agent", serder=icp, sigers=[siger])


### PR DESCRIPTION
While booting when the Client AID is already incepted, KERIA respond with "500 Internal Server Error"
This PR changes that behavior by catching the error and responding with error code 400 and the description received from the upper class that in this case is "Already incepted".

I assigned error 400 because I couldn't find an error more descriptive. There's an error code 409 "Conflicting" that can be use if it's considered more appropriate. 