### PR TITLE
Working endpoint for creating credential registries through a KERIA Agent

### DIFF
--- a/src/keria/app/aiding.py
+++ b/src/keria/app/aiding.py
@@ -178,7 +178,6 @@ class AgentResourceEnd:
                         cipher = coring.Cipher(qb64=prx)
                         agent.mgr.rb.nxts.put(keys=digers[idx].qb64b, val=cipher)
 
-        print(f"deleting {sxlt}")
         agent.mgr.delete_sxlt()
 
         rep.status = falcon.HTTP_204
@@ -356,12 +355,13 @@ class IdentifierCollectionEnd:
                     rep.data = op.to_json().encode("utf-8")
 
                 else:
-                    rep.status = falcon.HTTP_200
-                    rep.data = serder.raw
+                    rep.status = falcon.HTTP_202
+                    op = agent.monitor.submit(hab.kever.prefixer.qb64, longrunning.OpTypes.done,
+                                              metadata=dict(response=serder.ked))
+                    rep.data = op.to_json().encode("utf-8")
 
         except (kering.AuthError, ValueError) as e:
-            rep.status = falcon.HTTP_400
-            rep.text = e.args[0]
+            raise falcon.HTTPBadRequest(description=e.args[0])
 
 
 class IdentifierResourceEnd:
@@ -402,13 +402,13 @@ class IdentifierResourceEnd:
             typ = Ilks.ixn if req.params.get("type") == "ixn" else Ilks.rot
 
             if typ in (Ilks.rot,):
-                data = self.rotate(agent, name, body)
+                op = self.rotate(agent, name, body)
             else:
-                data = self.interact(agent, name, body)
+                op = self.interact(agent, name, body)
 
             rep.status = falcon.HTTP_200
             rep.content_type = "application/json"
-            rep.data = data
+            rep.data = op.to_json().encode("utf-8")
 
         except (kering.AuthError, ValueError) as e:
             raise falcon.HTTPBadRequest(description=e.args[0])
@@ -461,21 +461,23 @@ class IdentifierResourceEnd:
             agent.groups.append(dict(pre=hab.pre, serder=serder, sigers=sigers, smids=smids, rmids=rmids))
             op = agent.monitor.submit(serder.pre, longrunning.OpTypes.group, metadata=dict(sn=serder.sn))
 
-            return op.to_json().encode("utf-8")
+            return op
 
         if hab.kever.delegator:
             agent.anchors.append(dict(alias=name, pre=hab.pre, sn=0))
             op = agent.monitor.submit(hab.kever.prefixer.qb64, longrunning.OpTypes.delegation,
                                       metadata=dict(pre=hab.pre, sn=hab.kever.sn))
-            return op.to_json().encode("utf-8")
+            return op
 
         if hab.kever.wits:
             agent.witners.append(dict(serder=serder))
             op = agent.monitor.submit(hab.kever.prefixer.qb64, longrunning.OpTypes.witness,
                                       metadata=dict(sn=hab.kever.sn))
-            return op.to_json().encode("utf-8")
+            return op
 
-        return serder.raw
+        op = agent.monitor.submit(hab.kever.prefixer.qb64, longrunning.OpTypes.done,
+                                  metadata=dict(response=serder.ked))
+        return op
 
     @staticmethod
     def interact(agent, name, body):
@@ -502,15 +504,17 @@ class IdentifierResourceEnd:
             agent.groups.append(dict(pre=hab.pre, serder=serder, sigers=sigers))
             op = agent.monitor.submit(serder.pre, longrunning.OpTypes.group, metadata=dict(sn=serder.sn))
 
-            return op.to_json().encode("utf-8")
+            return op
 
         if hab.kever.wits:
             agent.witners.append(dict(serder=serder))
             op = agent.monitor.submit(hab.kever.prefixer.qb64, longrunning.OpTypes.witness,
                                       metadata=dict(sn=hab.kever.sn))
-            return op.to_json().encode("utf-8")
+            return op
 
-        return serder.raw
+        op = agent.monitor.submit(hab.kever.prefixer.qb64, longrunning.OpTypes.done,
+                                  metadata=dict(response=serder.ked))
+        return op
 
 
 def info(hab, rm, full=False):

--- a/src/keria/core/longrunning.py
+++ b/src/keria/core/longrunning.py
@@ -17,9 +17,10 @@ from keri.db import dbing, koming
 from keri.help import helping
 
 # long running operationt types
-Typeage = namedtuple("Tierage", 'oobi witness delegation group query')
+Typeage = namedtuple("Tierage", 'oobi witness delegation group query registry done')
 
-OpTypes = Typeage(oobi="oobi", witness='witness', delegation='delegation', group='group', query='query')
+OpTypes = Typeage(oobi="oobi", witness='witness', delegation='delegation', group='group', query='query',
+                  registry='registry', done='done')
 
 
 @dataclass_json
@@ -277,6 +278,13 @@ class Monitor:
                         operation.response = kever.state().ked
                     else:
                         operation.done = False
+
+        elif op.type in (OpTypes.registry, ):
+            pass
+
+        elif op.type in (OpTypes.done, ):
+            operation.done = True
+            operation.response = op.metadata["response"]
 
         else:
             operation.done = True

--- a/tests/app/test_agenting.py
+++ b/tests/app/test_agenting.py
@@ -17,6 +17,7 @@ from keri import kering
 from keri.app import habbing, configing, oobiing
 from keri.app.agenting import Receiptor
 from keri.core import coring
+from keri.core.coring import MtrDex
 from keri.db import basing
 from keri.vdr import credentialing
 
@@ -134,6 +135,40 @@ def test_agency():
             shutil.rmtree(f'/usr/local/var/keri/ks/{base}')
         if os.path.exists(f'/usr/local/var/keri/adb/{base}'):
             shutil.rmtree(f'/usr/local/var/keri/adb/{base}')
+
+
+def test_boot_ends(helpers):
+    agency = agenting.Agency(name="agency", bran=None, temp=True)
+    doist = doing.Doist(limit=1.0, tock=0.03125, real=True)
+    doist.enter(doers=[agency])
+
+    serder, sigers = helpers.controller()
+    assert serder.pre == helpers.controllerAID
+
+    app = falcon.App()
+    client = testing.TestClient(app)
+
+    bootEnd = agenting.BootEnd(agency)
+    app.add_route("/boot", bootEnd)
+
+    body = dict(
+        icp=serder.ked,
+        sig=sigers[0].qb64,
+        salty=dict(
+            stem='signify:aid', pidx=0, tier='low', sxlt='OBXYZ',
+            icodes=[MtrDex.Ed25519_Seed], ncodes=[MtrDex.Ed25519_Seed]
+        )
+    )
+
+    rep = client.simulate_post("/boot", body=json.dumps(body).encode("utf-8"))
+    assert rep.status_code == 202
+
+    rep = client.simulate_post("/boot", body=json.dumps(body).encode("utf-8"))
+    assert rep.status_code == 400
+    assert rep.json == {
+        'title': 'agent already exists',
+        'description': 'agent for controller EK35JRNdfVkO4JwhXaSTdV4qzB_ibk_tGJmSVcY4pZqx already exists'
+    }
 
 
 def test_witnesser(helpers):
@@ -294,7 +329,8 @@ def test_oobi_ends(seeder, helpers):
         assert url == 'http://127.0.0.1:5644/oobi/E6Dqo6tHmYTuQ3Lope4mZF_4hBoGJl93cBHRekr_iD_A/witness/'
         assert item.oobialias == 'sal'
 
-        aid = helpers.createAid(client, "aggie", salt)
+        op = helpers.createAid(client, "aggie", salt)
+        aid = op["response"]
         aggiePre = aid['i']
         assert aggiePre == "EHgwVwQT15OJvilVvW57HE4w0-GPs_Stj2OFoAHZSysY"
 

--- a/tests/app/test_aiding.py
+++ b/tests/app/test_aiding.py
@@ -167,7 +167,7 @@ def test_identifier_collection_end(helpers):
                 }
 
         res = client.simulate_post(path="/identifiers", body=json.dumps(body))
-        assert res.status_code == 200
+        assert res.status_code == 202
 
         # Try to resubmit and get an error
         res = client.simulate_post(path="/identifiers", body=json.dumps(body))
@@ -192,7 +192,7 @@ def test_identifier_collection_end(helpers):
                 'salty': {'stem': 'signify:aid', 'pidx': 1, 'tier': 'low', 'sxlt': sxlt,
                           'icodes': [MtrDex.Ed25519_Seed], 'ncodes': [MtrDex.Ed25519_Seed]}}
         res = client.simulate_post(path="/identifiers", body=json.dumps(body))
-        assert res.status_code == 200
+        assert res.status_code == 202
 
         res = client.simulate_get(path="/identifiers")
         assert res.status_code == 200
@@ -407,7 +407,7 @@ def test_identifier_collection_end(helpers):
                 }
                 }
         res = client.simulate_post(path="/identifiers", body=json.dumps(body))
-        assert res.status_code == 200
+        assert res.status_code == 202
 
         # Resubmit and get an error
         res = client.simulate_post(path="/identifiers", body=json.dumps(body))
@@ -457,7 +457,7 @@ def test_identifier_collection_end(helpers):
                 }
         res = client.simulate_put(path="/identifiers/randy1", body=json.dumps(body))
         assert res.status_code == 200
-        assert res.json == serder.ked
+        assert res.json["response"] == serder.ked
         res = client.simulate_get(path="/identifiers")
         assert res.status_code == 200
         assert len(res.json) == 1
@@ -475,7 +475,7 @@ def test_identifier_collection_end(helpers):
                 }
         res = client.simulate_put(path="/identifiers/randy1?type=ixn", body=json.dumps(body))
         assert res.status_code == 200
-        assert res.json == serder.ked
+        assert res.json["response"] == serder.ked
 
         res = client.simulate_get(path=f"/events?pre={pre}")
         assert res.status_code == 200
@@ -494,7 +494,8 @@ def test_identifier_collection_end(helpers):
 
         client = testing.TestClient(app)
         salt = b'0123456789abcdef'
-        aid = helpers.createAid(client, "delegator", salt)
+        op = helpers.createAid(client, "delegator", salt)
+        aid = op["response"]
         delpre = aid['i']
         assert delpre == "EHgwVwQT15OJvilVvW57HE4w0-GPs_Stj2OFoAHZSysY"
         op = helpers.createAid(client, "delegatee", salt, delpre=delpre)
@@ -522,7 +523,7 @@ def test_identifier_collection_end(helpers):
                 }
                 }
         res = client.simulate_post(path="/identifiers", body=json.dumps(body))
-        assert res.status_code == 200
+        assert res.status_code == 202
 
 def test_challenge_ends(helpers):
     with helpers.openKeria() as (agency, agent, app, client):
@@ -557,7 +558,8 @@ def test_challenge_ends(helpers):
 
         # Create an AID to test against
         salt = b'0123456789abcdef'
-        aid = helpers.createAid(client, "pal", salt)
+        op = helpers.createAid(client, "pal", salt)
+        aid = op["response"]
 
         payload = dict(i=aid['i'], words=words)
         exn = exchanging.exchange(route="/challenge/response", payload=payload)
@@ -599,7 +601,8 @@ def test_contact_ends(helpers):
         end = aiding.IdentifierCollectionEnd()
         app.add_route("/identifiers", end)
         salt = b'0123456789abcdef'
-        aid = helpers.createAid(client, "pal", salt)
+        op = helpers.createAid(client, "pal", salt)
+        aid = op["response"]
         palPre = aid["i"]
 
         msgs = bytearray()
@@ -833,7 +836,7 @@ def test_identifier_resource_end(helpers):
                 }
 
         res = client.simulate_post(path="/identifiers", body=json.dumps(body))
-        assert res.status_code == 200
+        assert res.status_code == 202
 
         res = client.simulate_get(path="/identifiers/bad")
         assert res.status_code == 404

--- a/tests/app/test_indirecting.py
+++ b/tests/app/test_indirecting.py
@@ -26,7 +26,9 @@ def test_indirecting(helpers):
         resend = aiding.IdentifierResourceEnd()
         app.add_route("/identifiers", end)
         app.add_route("/identifiers/{name}", resend)
-        aid = helpers.createAid(client, "recipient", salt)
+        op = helpers.createAid(client, "recipient", salt)
+        aid = op["response"]
+
         assert aid["i"] == "EHgwVwQT15OJvilVvW57HE4w0-GPs_Stj2OFoAHZSysY"
 
         hab = hby.makeHab("test")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -143,6 +143,16 @@ class Helpers:
         return serder, signers
 
     @staticmethod
+    def interact(pre, bran, pidx, ridx, sn, dig, data):
+        serder = eventing.interact(pre=pre, dig=dig, sn=sn, data=data)
+        salter = coring.Salter(raw=bran)
+        creator = keeping.SaltyCreator(salt=salter.qb64, stem="signify:aid", tier=coring.Tiers.low)
+
+        signers = creator.create(pidx=pidx, ridx=ridx, tier=coring.Tiers.low, temp=False, count=1)
+        sigers = [signer.sign(ser=serder.raw, index=0).qb64 for signer in signers]
+        return serder, sigers
+
+    @staticmethod
     def inceptRandy(bran, count=1, sith="1", wits=None, toad="0"):
         if wits is None:
             wits = []

--- a/tests/core/test_httping.py
+++ b/tests/core/test_httping.py
@@ -9,7 +9,7 @@ class HandleCORSTest(unittest.TestCase):
         self.cors_handler = HandleCORS()
 
     def test_process_request(self):
-        req = helpers.create_environ(method='GET')
+        req = helpers.create_req(method='GET')
         resp = falcon.Response()
 
         self.cors_handler.process_request(req, resp)
@@ -20,7 +20,7 @@ class HandleCORSTest(unittest.TestCase):
         self.assertEqual(resp.get_header('Access-Control-Max-Age'), '1728000')
 
     def test_process_request_options_method(self):
-        req = helpers.create_environ(method='OPTIONS')
+        req = helpers.create_req(method='OPTIONS')
         resp = falcon.Response()
 
         with self.assertRaises(HTTPStatus) as cm:


### PR DESCRIPTION
This PR includes:

* Working credential registry inception endpoint
* Fix from @rodolfomiranda for returning a 400 instead of 500 when trying to create the same Agent twice
* Change to AID endpoints to have them always return an Operation instead of sometimes a Serder.

TODO: Implement longrunning operation responses for registry ops.