### PR TITLE
Advanced credential searching and sorting API

### DIFF
--- a/src/keria/app/agenting.py
+++ b/src/keria/app/agenting.py
@@ -276,6 +276,7 @@ class Agent(doing.DoDoer):
 
         self.monitor = longrunning.Monitor(hby=hby, swain=self.swain, counselor=self.counselor, temp=hby.temp,
                                            registrar=self.registrar, credentialer=self.credentialer)
+        self.seeker = basing.Seeker(db=hby.db, reger=self.rgy.reger, reopen=True, temp=self.hby.temp)
 
         issueHandler = protocoling.IssueHandler(hby=hby, rgy=rgy, notifier=self.notifier)
         requestHandler = protocoling.PresentationRequestHandler(hby=hby, notifier=self.notifier)
@@ -317,6 +318,7 @@ class Agent(doing.DoDoer):
             Delegator(agentHab=agentHab, swain=self.swain, anchors=self.anchors),
             GroupRequester(hby=hby, agentHab=agentHab, postman=self.postman, counselor=self.counselor,
                            groups=self.groups),
+            SeekerDoer(seeker=self.seeker, cues=self.verifier.cues)
         ])
 
         super(Agent, self).__init__(doers=doers, always=True, **opts)
@@ -403,6 +405,25 @@ class Delegator(doing.Doer):
             self.swain.delegation(pre=msg["pre"], sn=sn, proxy=self.agentHab)
 
         return False
+
+
+class SeekerDoer(doing.Doer):
+
+    def __init__(self, seeker, cues):
+        self.seeker = seeker
+        self.cues = cues
+
+        super(SeekerDoer, self).__init__()
+
+    def recur(self, tyme=None):
+        if self.cues:
+            cue = self.cues.popleft()
+            if cue["kin"] == "saved":
+                creder = cue["creder"]
+                print(f"indexing {creder.said}")
+                self.seeker.index(said=creder.said)
+
+            self.cues.append(cue)
 
 
 class Initer(doing.Doer):

--- a/src/keria/db/basing.py
+++ b/src/keria/db/basing.py
@@ -4,8 +4,26 @@ KERIA
 keria.db.basing module
 
 """
+from dataclasses import dataclass
+
 from keri.core import coring
-from keri.db import dbing, subing
+from keri.db import dbing, subing, koming
+
+
+SCALAR_TYPES = ("string", "number")
+
+ISSUER_FIELD = coring.Pather(path=['i'])
+ISSUEE_FIELD = coring.Pather(path=['a', 'i'])
+SCHEMA_FIELD = coring.Pather(path=['s'])
+REGISTRY_FIELD = coring.Pather(path=['ri'])
+
+
+@dataclass
+class IndexRecord:
+    """ Registry Key keyed by Registry name
+    """
+    subkey: str
+    paths: list
 
 
 class AgencyBaser(dbing.LMDBer):
@@ -77,3 +95,161 @@ class AgencyBaser(dbing.LMDBer):
         self.aids = subing.CesrSuber(db=self,
                                      subkey='aids.',
                                      klas=coring.Prefixer)
+
+
+class Seeker(dbing.LMDBer):
+    """
+    Seeker indexes all credentials in the KERIpy `saved` Creder database.
+
+    Static indexes are created for issued by/schema and issued to/schema and dynamic indexes are
+    created for all top level scalar valued fields in the credential payload ('a' field).  The Seeker
+    uses the schema of each credential to determine the payload fields to index by.
+
+    """
+
+    TailDirPath = "keri/seekdb"
+    AltTailDirPath = ".keri/seekdb"
+    TempPrefix = "keri_seekdb_"
+    MaxNamedDBs = 50
+
+    def __init__(self, db, reger, headDirPath=None, perm=None, reopen=False, **kwa):
+        """
+        Setup named sub databases.
+
+        Inherited Parameters:
+            name is str directory path name differentiator for main database
+                When system employs more than one keri database, name allows
+                differentiating each instance by name
+                default name='main'
+            temp is boolean, assign to .temp
+                True then open in temporary directory, clear on close
+                Othewise then open persistent directory, do not clear on close
+                default temp=False
+            headDirPath is optional str head directory pathname for main database
+                If not provided use default .HeadDirpath
+                default headDirPath=None so uses self.HeadDirPath
+            perm is numeric optional os dir permissions mode
+                default perm=None so do not set mode
+            reopen is boolean, IF True then database will be reopened by this init
+                default reopen=True
+
+
+        """
+        self.db = db
+        self.reger = reger
+        self.indexes = dict()
+
+        self.schIdx = None
+        self.dynIdx = None
+
+        super(Seeker, self).__init__(headDirPath=headDirPath, perm=perm,
+                                     reopen=reopen, **kwa)
+
+    def reopen(self, **kwa):
+        super(Seeker, self).reopen(**kwa)
+
+        # List of indexs for a given schema
+        self.schIdx = subing.IoSetSuber(db=self, subkey="schIdx.")
+        # List of dynamically created indexes to be recreated at load
+        self.dynIdx = koming.Komer(db=self,
+                                   subkey='dynIdx.',
+                                   schema=IndexRecord, )
+
+        for name, idx in self.dynIdx.getItemIter():
+            self.indexes[name] = subing.CesrDupSuber(db=self, subkey=idx.subkey, klas=coring.Saider)
+
+        # Create persistent Indexes if they don't already exist
+        self.createIndex(SCHEMA_FIELD.qb64)
+        self.createIndex(REGISTRY_FIELD.qb64)
+
+        # Index of credentials by issuer/issuee.
+        for field in (ISSUER_FIELD, ISSUEE_FIELD):
+            self.createIndex(field.qb64)
+            subkey = f"{field.qb64}.{SCHEMA_FIELD.qb64}"
+            self.createIndex(subkey)
+
+    def createIndex(self, key):
+        if self.dynIdx.get(keys=(key,)) is None:
+            self.indexes[key] = subing.CesrDupSuber(db=self, subkey=key, klas=coring.Saider)
+            self.dynIdx.pin(keys=(key,), val=IndexRecord(subkey=key, paths=[key]))
+
+    def index(self, said):
+
+        if (saider := self.reger.saved.get(keys=(said,))) is None:
+            raise ValueError(f"{said} is not a verified credential")
+
+        creder = self.reger.creds.get(keys=(saider.qb64, ))
+        saider = coring.Saider(qb64b=creder.saidb)
+
+        # Load schema index and if not indexed in schIdx, index it.
+        schemaSaid = creder.schema
+        if (indexes := self.schIdx.get(keys=(schemaSaid,))) is None:
+            indexes = self.generateIndexes(schemaSaid)
+
+        for index in indexes:
+            db = self.indexes[index]
+            idx = self.dynIdx.get(keys=(index,))
+            values = []
+            for path in idx.paths:
+                pather = coring.Pather(qb64=path)
+                values.append(pather.resolve(creder.crd))
+
+            value = "".join(values)
+            print(f"for {idx.paths}, {value} -> {saider}")
+            db.add(keys=(value,), val=saider)
+
+    def generateIndexes(self, said):
+        """ Parse schema of said, create schIdx entry keyed to said of schema and the subkey indexes in
+        self.indexes
+
+        """
+        if (schemer := self.db.schema.get(keys=(said,))) is None:
+            raise ValueError(f"{said} is not a valid schema SAID to index")
+
+        properties = schemer.sed["properties"]
+        payload = properties['a']
+        if isinstance(payload, list):
+            for p in payload:
+                if p["type"] == "object":
+                    payload = p
+                    break
+
+        if not isinstance(payload, dict):
+            raise ValueError(f"schema with SAID={said} is not value, no payload of values")
+
+        properties = payload["properties"]
+
+        attestation = 'i' not in payload
+
+        # Assign single field ISSUER index and ISSUER/SCHEMA:
+        self.schIdx.add(keys=(said,), val=ISSUER_FIELD.qb64b)
+        subkey = f"{ISSUER_FIELD.qb64}.{SCHEMA_FIELD.qb64}"
+        self.schIdx.add(keys=(said,), val=subkey.encode("UTF-8"))
+
+        # Assign single field ISSUEE index and ISSUEE/SCHEMA if needed
+        if not attestation:
+            self.schIdx.add(keys=(said,), val=ISSUEE_FIELD.qb64b)
+            subkey = f"{ISSUEE_FIELD.qb64}.{SCHEMA_FIELD.qb64}"
+            self.schIdx.add(keys=(said,), val=subkey.encode("UTF-8"))
+
+        for p, val in properties.items():
+            if val["type"] not in SCALAR_TYPES:
+                continue
+
+            pather = coring.Pather(path=['a', p])
+            if pather.qb64 not in self.indexes:
+                self.indexes[pather.qb64] = subing.CesrDupSuber(db=self, subkey=pather.qb64, klas=coring.Saider)
+                idx = IndexRecord(subkey=pather.qb64, paths=[pather.qb64])
+                self.dynIdx.pin(keys=(pather.qb64,), val=idx)
+            self.schIdx.add(keys=(said,), val=pather.qb64b)
+
+            for field in (ISSUER_FIELD, ISSUEE_FIELD, SCHEMA_FIELD):
+                subkey = f"{field.qb64}.{pather.qb64}"
+                if subkey not in self.indexes:
+                    self.indexes[subkey] = subing.CesrDupSuber(db=self, subkey=subkey, klas=coring.Saider)
+                    idx = IndexRecord(subkey=subkey, paths=[field.qb64, pather.qb64])
+                    self.dynIdx.pin(keys=(subkey,), val=idx)
+
+                self.schIdx.add(keys=(said,), val=subkey)
+
+        return [index for index in self.schIdx.get(keys=(said,))]

--- a/tests/app/test_basing.py
+++ b/tests/app/test_basing.py
@@ -8,7 +8,6 @@ Testing the database classes
 import random
 
 from keri.app import habbing
-from keri.core import coring
 
 from keria.db import basing
 
@@ -96,24 +95,46 @@ def test_seeker(helpers, seeder, mockHelpingNowUTC):
 
         issuer.createRegistry(issuerHab.pre, name="issuer")
 
-        for _ in range(50):
-            LEI = randomLEI()
+        for LEI in LEIs:
             qvisaid = issuer.issueQVIvLEI("issuer", issuerHab, issueeHab.pre, LEI)
             seeker.index(qvisaid)
 
-        for _ in range(50):
-            LEI = randomLEI()
-            lesaid = issuer.issueLegalEntityvLEI("issuer", issuerHab, issueeHab.pre, LEI)
-            seeker.index(lesaid)
+        saids = seeker.find({})
+        assert len(list(saids)) == 25
 
-        saids = seeker.find(
-            fields=['-i'],
-            values=[issuerHab.pre],
-            order=['-a-LEI'],
-            start=20,
-            limit=30
-        )
+        saids = seeker.find({}).limit(50)
+        assert len(list(saids)) == 50
 
+        saids = seeker.find({'-d': "EAzc9zFLaK22zbrKDGIgKtrpDBNKWKvl8B0FKYAo19z_"})
+        assert list(saids) == ['EAzc9zFLaK22zbrKDGIgKtrpDBNKWKvl8B0FKYAo19z_']
+
+        saids = seeker.find({'-a-LEI': "OKB9487U4IDOG92KVVFN"})
+        assert list(saids) == ['EJJzx89f1sTNdOPGHRx3e7ukcFW0F4nq9o7e8taLoNXt']
+
+        saids = seeker.find({'-a-LEI': {"$eq": "OKB9487U4IDOG92KVVFN"}})
+        assert list(saids) == ['EJJzx89f1sTNdOPGHRx3e7ukcFW0F4nq9o7e8taLoNXt']
+
+        saids = seeker.find({}).sort(['-a-LEI']).limit(5)
+        assert list(saids) == ['EAzc9zFLaK22zbrKDGIgKtrpDBNKWKvl8B0FKYAo19z_',
+                               'EFW50stHOz-0_8Dh7EcYs0DsLZ06d4hwGKjRbOB8hgnR',
+                               'EBiyZ2iyZodulzaUACzl_Cg6fRc1D0EPyNOooFemFK3e',
+                               'EIn3igRf049kPQvpLjjLjU80QITreObH4BJguAxMPqis',
+                               'ENnhxrOOeKIESS7_Yk7yVkJLm6blSOedACZvKFdMcxg5']
+
+        saids = seeker.find({}).sort(['-a-LEI']).skip(10).limit(5)
+        assert list(saids) == ['EDuqEITx0Jx8zZOCdqJU3e-RHvJS0UDZjeeBYPvB-XcK',
+                               'ELic0LPsg_J9XietLYJ4MrOgSv3v6WqqBscrJMhZOV-V',
+                               'EJ8_Bzr5vYZkaHmB-MW7VFYdgADg_W8MCZwWG7syjsu3',
+                               'EPk5vCk-LLOmwityjKBn7HB92w2ViP-vro5_QaK2ueAd',
+                               'EF7vDsfikOf_rEX2Lc_LFQoQSSxJxUr1Xkxlj9XeMu_l']
+
+        saids = seeker.find({'-a-LEI': {'$begins': 'Q'}}).sort(['-a-LEI'])
+        assert list(saids) == ['EJCprDNJIkHzDkMm__X1zcz65YBMtaBhjugIPXN0R2iC',
+                               'EGO5Dh4ADbgDSTj-0X3452s7R6iAjFG2amY1qXlhqVxe',
+                               'EOMWNhcIYPuXkh-LDZTc--sVL-cOINWNINfqO9kUhnBG']
+
+        print(f"\nIssued by {issuerHab.pre}")
+        saids = seeker.find({'-i': {'$eq': issuerHab.pre}}).sort(['-a-LEI']).skip(25).limit(6)
         for said in saids:
             creder = seeker.reger.creds.get(keys=(said,))
             print(creder.ked['a']['LEI'])
@@ -126,3 +147,57 @@ def randomLEI():
         lei.append(random.choice(values))
 
     return "".join(lei)
+
+
+LEIs = [
+    "0TRMLT6GMYU4KR2LF53X",
+    "2YYF59AGE86D0414IPXE",
+    "4O18CPBR0M98BL0XLKMV",
+    "61U5P9O67BU0AJDG09V3",
+    "71TPKZZ3BZE76P688I1J",
+    "729OF364T863RFDT7U9T",
+    "78I9GKEFM361IFY3PIN0",
+    "88L360XFZMMQRVOBTOVJ",
+    "8BY2XVDFG1KFJN51NHO7",
+    "9DTTZO1AZAI3NCR4CDJE",
+    "AK0BQ8AMUP83C44V7ROV",
+    "ARFTR4V73K611OMR7ERY",
+    "CUAJFJD60XF2BGRCXAKG",
+    "DIJRO3BFDNCPA69LPEV1",
+    "DZZ6D24KM7IM9EPZFV1B",
+    "EL55H00R3CZ831I0V9AX",
+    "FALI868UXRJ2RMVV3IL1",
+    "GIHOVFO3YX15CQ77104O",
+    "ICC05EF6YQCT3DNPTM9Y",
+    "IP3X8NN44Y95LERBJTV3",
+    "IU0QV4FAIVUUDHT76PLQ",
+    "JJ2M6KI1UVLR9NMLBQR4",
+    "JJFMBB5C56LITKKG0TEJ",
+    "K1BC76MZ5JK5G3289MJH",
+    "KJJ4LJN00ZHA4VUV8MAO",
+    "LEYGGPUNV3LJY3KPFDHP",
+    "LRK3QNUZJNJY1VD08MV2",
+    "MNUHRN28GQN7VM0G0AKE",
+    "N6IBQ8JMQMNOC9RKPR41",
+    "NROKZU334DJVEFVZ7G2P",
+    "NYCYXM3CRFZJRR6REOAG",
+    "O4HPA5M8C3M3791O66VA",
+    "OKB9487U4IDOG92KVVFN",
+    "OT3VCOMUQUP4BOE2KKG4",
+    "OVRCIN9K9I6CGJYHJO2X",
+    "P7QQOV1918ONIGJ2XR8R",
+    "QA3NXK31GVLM2I6Z93I0",
+    "QNA8ZL2DODTF3R87GLX1",
+    "QNRDPO6T79ZVRP9C296U",
+    "TRM5JMV0G610VJ1102BT",
+    "U6452GAE5C4TVRUY9EIX",
+    "U6GNXGXNJ1NTV9X7BHO4",
+    "U7B3X764DAI54QKIL6NV",
+    "V6VXHQ9Y8NB2CGRED7LD",
+    "Y0HFPYCR42XB09ODFV07",
+    "Y3206FITOG3GRX6QM47Y",
+    "YJ6XN9AIRRTR58DZ5I9H",
+    "YLBCIFLMZXIDFH96Z66V",
+    "ZUCD1UCNH83634ZIM8TC",
+    "ZUQA6QTJDNYPF3DLP9NH",
+]

--- a/tests/app/test_basing.py
+++ b/tests/app/test_basing.py
@@ -107,9 +107,9 @@ def test_seeker(helpers, seeder, mockHelpingNowUTC):
             seeker.index(lesaid)
 
         saids = seeker.find(
-            fields=[coring.Pather(path=['i']).qb64],
+            fields=['-i'],
             values=[issuerHab.pre],
-            order=[coring.Pather(path=['a', 'LEI']).qb64],
+            order=['-a-LEI'],
             start=20,
             limit=30
         )

--- a/tests/app/test_basing.py
+++ b/tests/app/test_basing.py
@@ -5,16 +5,18 @@ keria.app.basing module
 
 Testing the database classes
 """
+import random
+
 from keri.app import habbing
-from keri.vdr import viring
+from keri.core import coring
 
 from keria.db import basing
 
 QVI_SAID = "EFgnk_c08WmZGgv9_mpldibRuqFMTQN-rAgtD-TCOwbs"
-LE_SAID = "ED892b40P_GcESs3wOcc2zFvL_GVi2Ybzp9isNTZKqP0"
+LE_SAID = "ENTAoj2oNBFpaniRswwPcca9W1ElEeH2V7ahw68HV4G5"
 
 
-def test_seeker(helpers, seeder):
+def test_seeker(helpers, seeder, mockHelpingNowUTC):
     salt = b'0123456789abcdef'
 
     with habbing.openHab(name="hal", salt=salt, temp=True) as (issueeHby, issueeHab), \
@@ -32,24 +34,32 @@ def test_seeker(helpers, seeder):
         assert indexes == ['5AABAA-i',
                            '5AABAA-i.5AABAA-s',
                            '4AAB-a-d',
-                           '5AABAA-i.4AAB-a-d',
-                           '4AAB-a-i.4AAB-a-d',
                            '5AABAA-s.4AAB-a-d',
+                           '5AABAA-i.4AAB-a-d',
+                           '5AABAA-i.5AABAA-s.4AAB-a-d',
+                           '4AAB-a-i.4AAB-a-d',
+                           '4AAB-a-i.5AABAA-s.4AAB-a-d',
                            '4AAB-a-i',
-                           '5AABAA-i.4AAB-a-i',
-                           '4AAB-a-i.4AAB-a-i',
                            '5AABAA-s.4AAB-a-i',
+                           '5AABAA-i.4AAB-a-i',
+                           '5AABAA-i.5AABAA-s.4AAB-a-i',
+                           '4AAB-a-i.4AAB-a-i',
+                           '4AAB-a-i.5AABAA-s.4AAB-a-i',
                            '6AACAAA-a-dt',
-                           '5AABAA-i.6AACAAA-a-dt',
-                           '4AAB-a-i.6AACAAA-a-dt',
                            '5AABAA-s.6AACAAA-a-dt',
+                           '5AABAA-i.6AACAAA-a-dt',
+                           '5AABAA-i.5AABAA-s.6AACAAA-a-dt',
+                           '4AAB-a-i.6AACAAA-a-dt',
+                           '4AAB-a-i.5AABAA-s.6AACAAA-a-dt',
                            '5AACAA-a-LEI',
+                           '5AABAA-s.5AACAA-a-LEI',
                            '5AABAA-i.5AACAA-a-LEI',
+                           '5AABAA-i.5AABAA-s.5AACAA-a-LEI',
                            '4AAB-a-i.5AACAA-a-LEI',
-                           '5AABAA-s.5AACAA-a-LEI']
+                           '4AAB-a-i.5AABAA-s.5AACAA-a-LEI']
 
         # Test that the index tables were correctly ereated
-        assert len(seeker.indexes) == 21
+        assert len(seeker.indexes) == 29
 
         indexes = seeker.generateIndexes(LE_SAID)
 
@@ -57,28 +67,62 @@ def test_seeker(helpers, seeder):
         assert indexes == ['5AABAA-i',
                            '5AABAA-i.5AABAA-s',
                            '4AAB-a-d',
-                           '5AABAA-i.4AAB-a-d',
-                           '4AAB-a-i.4AAB-a-d',
                            '5AABAA-s.4AAB-a-d',
+                           '5AABAA-i.4AAB-a-d',
+                           '5AABAA-i.5AABAA-s.4AAB-a-d',
+                           '4AAB-a-i.4AAB-a-d',
+                           '4AAB-a-i.5AABAA-s.4AAB-a-d',
                            '4AAB-a-i',
-                           '5AABAA-i.4AAB-a-i',
-                           '4AAB-a-i.4AAB-a-i',
                            '5AABAA-s.4AAB-a-i',
+                           '5AABAA-i.4AAB-a-i',
+                           '5AABAA-i.5AABAA-s.4AAB-a-i',
+                           '4AAB-a-i.4AAB-a-i',
+                           '4AAB-a-i.5AABAA-s.4AAB-a-i',
                            '6AACAAA-a-dt',
-                           '5AABAA-i.6AACAAA-a-dt',
-                           '4AAB-a-i.6AACAAA-a-dt',
                            '5AABAA-s.6AACAAA-a-dt',
+                           '5AABAA-i.6AACAAA-a-dt',
+                           '5AABAA-i.5AABAA-s.6AACAAA-a-dt',
+                           '4AAB-a-i.6AACAAA-a-dt',
+                           '4AAB-a-i.5AABAA-s.6AACAAA-a-dt',
                            '5AACAA-a-LEI',
+                           '5AABAA-s.5AACAA-a-LEI',
                            '5AABAA-i.5AACAA-a-LEI',
+                           '5AABAA-i.5AABAA-s.5AACAA-a-LEI',
                            '4AAB-a-i.5AACAA-a-LEI',
-                           '5AABAA-s.5AACAA-a-LEI']
+                           '4AAB-a-i.5AABAA-s.5AACAA-a-LEI']
 
         # Assure that no knew index tables needed to be created
-        assert len(seeker.indexes) == 21
+        assert len(seeker.indexes) == 29
 
         issuer.createRegistry(issuerHab.pre, name="issuer")
-        qvisaid = issuer.issueQVIvLEI("issuer", issuerHab, issueeHab.pre, "984500E5DEFDBQ1O9038")
 
-        seeker.index(qvisaid)
+        for _ in range(50):
+            LEI = randomLEI()
+            qvisaid = issuer.issueQVIvLEI("issuer", issuerHab, issueeHab.pre, LEI)
+            seeker.index(qvisaid)
+
+        for _ in range(50):
+            LEI = randomLEI()
+            lesaid = issuer.issueLegalEntityvLEI("issuer", issuerHab, issueeHab.pre, LEI)
+            seeker.index(lesaid)
+
+        saids = seeker.find(
+            fields=[coring.Pather(path=['i']).qb64],
+            values=[issuerHab.pre],
+            order=[coring.Pather(path=['a', 'LEI']).qb64],
+            start=20,
+            limit=30
+        )
+
+        for said in saids:
+            creder = seeker.reger.creds.get(keys=(said,))
+            print(creder.ked['a']['LEI'])
 
 
+def randomLEI():
+    values = "0123456789ABCDEFGHIJKLNMOPQRTUVXZY"
+    lei = []
+    for _ in range(20):
+        lei.append(random.choice(values))
+
+    return "".join(lei)

--- a/tests/app/test_basing.py
+++ b/tests/app/test_basing.py
@@ -1,0 +1,84 @@
+# -*- encoding: utf-8 -*-
+"""
+KERIA
+keria.app.basing module
+
+Testing the database classes
+"""
+from keri.app import habbing
+from keri.vdr import viring
+
+from keria.db import basing
+
+QVI_SAID = "EFgnk_c08WmZGgv9_mpldibRuqFMTQN-rAgtD-TCOwbs"
+LE_SAID = "ED892b40P_GcESs3wOcc2zFvL_GVi2Ybzp9isNTZKqP0"
+
+
+def test_seeker(helpers, seeder):
+    salt = b'0123456789abcdef'
+
+    with habbing.openHab(name="hal", salt=salt, temp=True) as (issueeHby, issueeHab), \
+            habbing.openHab(name="issuer", salt=salt, temp=True) as (issuerHby, issuerHab), \
+            helpers.withIssuer(name="issuer", hby=issuerHby) as issuer:
+
+        seeker = basing.Seeker(db=issuerHby.db, reger=issuer.rgy.reger, reopen=True, temp=True)
+
+        seeder.seedSchema(issueeHby.db)
+        seeder.seedSchema(issuerHby.db)
+
+        indexes = seeker.generateIndexes(QVI_SAID)
+
+        # Verify the indexes created for the QVI schema
+        assert indexes == ['5AABAA-i',
+                           '5AABAA-i.5AABAA-s',
+                           '4AAB-a-d',
+                           '5AABAA-i.4AAB-a-d',
+                           '4AAB-a-i.4AAB-a-d',
+                           '5AABAA-s.4AAB-a-d',
+                           '4AAB-a-i',
+                           '5AABAA-i.4AAB-a-i',
+                           '4AAB-a-i.4AAB-a-i',
+                           '5AABAA-s.4AAB-a-i',
+                           '6AACAAA-a-dt',
+                           '5AABAA-i.6AACAAA-a-dt',
+                           '4AAB-a-i.6AACAAA-a-dt',
+                           '5AABAA-s.6AACAAA-a-dt',
+                           '5AACAA-a-LEI',
+                           '5AABAA-i.5AACAA-a-LEI',
+                           '4AAB-a-i.5AACAA-a-LEI',
+                           '5AABAA-s.5AACAA-a-LEI']
+
+        # Test that the index tables were correctly ereated
+        assert len(seeker.indexes) == 21
+
+        indexes = seeker.generateIndexes(LE_SAID)
+
+        # Test the indexes assigned to the LE schema
+        assert indexes == ['5AABAA-i',
+                           '5AABAA-i.5AABAA-s',
+                           '4AAB-a-d',
+                           '5AABAA-i.4AAB-a-d',
+                           '4AAB-a-i.4AAB-a-d',
+                           '5AABAA-s.4AAB-a-d',
+                           '4AAB-a-i',
+                           '5AABAA-i.4AAB-a-i',
+                           '4AAB-a-i.4AAB-a-i',
+                           '5AABAA-s.4AAB-a-i',
+                           '6AACAAA-a-dt',
+                           '5AABAA-i.6AACAAA-a-dt',
+                           '4AAB-a-i.6AACAAA-a-dt',
+                           '5AABAA-s.6AACAAA-a-dt',
+                           '5AACAA-a-LEI',
+                           '5AABAA-i.5AACAA-a-LEI',
+                           '4AAB-a-i.5AACAA-a-LEI',
+                           '5AABAA-s.5AACAA-a-LEI']
+
+        # Assure that no knew index tables needed to be created
+        assert len(seeker.indexes) == 21
+
+        issuer.createRegistry(issuerHab.pre, name="issuer")
+        qvisaid = issuer.issueQVIvLEI("issuer", issuerHab, issueeHab.pre, "984500E5DEFDBQ1O9038")
+
+        seeker.index(qvisaid)
+
+

--- a/tests/app/test_basing.py
+++ b/tests/app/test_basing.py
@@ -30,15 +30,17 @@ def test_seeker(helpers, seeder, mockHelpingNowUTC):
         indexes = seeker.generateIndexes(QVI_SAID)
 
         # Verify the indexes created for the QVI schema
-        assert indexes == ['5AABAA-i',
+        assert indexes == ['5AABAA-s',
+                           '5AABAA-i',
                            '5AABAA-i.5AABAA-s',
+                           '4AAB-a-i',
+                           '4AAB-a-i.5AABAA-s',
                            '4AAB-a-d',
                            '5AABAA-s.4AAB-a-d',
                            '5AABAA-i.4AAB-a-d',
                            '5AABAA-i.5AABAA-s.4AAB-a-d',
                            '4AAB-a-i.4AAB-a-d',
                            '4AAB-a-i.5AABAA-s.4AAB-a-d',
-                           '4AAB-a-i',
                            '5AABAA-s.4AAB-a-i',
                            '5AABAA-i.4AAB-a-i',
                            '5AABAA-i.5AABAA-s.4AAB-a-i',
@@ -63,15 +65,17 @@ def test_seeker(helpers, seeder, mockHelpingNowUTC):
         indexes = seeker.generateIndexes(LE_SAID)
 
         # Test the indexes assigned to the LE schema
-        assert indexes == ['5AABAA-i',
+        assert indexes == ['5AABAA-s',
+                           '5AABAA-i',
                            '5AABAA-i.5AABAA-s',
+                           '4AAB-a-i',
+                           '4AAB-a-i.5AABAA-s',
                            '4AAB-a-d',
                            '5AABAA-s.4AAB-a-d',
                            '5AABAA-i.4AAB-a-d',
                            '5AABAA-i.5AABAA-s.4AAB-a-d',
                            '4AAB-a-i.4AAB-a-d',
                            '4AAB-a-i.5AABAA-s.4AAB-a-d',
-                           '4AAB-a-i',
                            '5AABAA-s.4AAB-a-i',
                            '5AABAA-i.4AAB-a-i',
                            '5AABAA-i.5AABAA-s.4AAB-a-i',
@@ -133,11 +137,14 @@ def test_seeker(helpers, seeder, mockHelpingNowUTC):
                                'EGO5Dh4ADbgDSTj-0X3452s7R6iAjFG2amY1qXlhqVxe',
                                'EOMWNhcIYPuXkh-LDZTc--sVL-cOINWNINfqO9kUhnBG']
 
-        print(f"\nIssued by {issuerHab.pre}")
-        saids = seeker.find({'-i': {'$eq': issuerHab.pre}}).sort(['-a-LEI']).skip(25).limit(6)
-        for said in saids:
-            creder = seeker.reger.creds.get(keys=(said,))
-            print(creder.ked['a']['LEI'])
+        saids = seeker.find({'-i': {'$eq': issuerHab.pre}, '-a-LEI': {'$begins': 'Y'}}).sort(['-a-LEI'])
+        assert list(saids) == ['EA4KV-yecOHV8jt0F2vG7tYRkyikhuOloCXliit_KTHI',
+                               'EI9K4digb0UgEPi0ZT4Rw1DlSSx5NewLpxl4M-XurJMO',
+                               'ELAcuTv3lYs7P6N9uP6Ob2oQ10CWhTLpGWJOht5VPvPT',
+                               'EFl7rgKSxQdEsFomKbeXfSDfGG_9QE0oDzNQ9v8DsJmJ']
+
+        saids = seeker.find({'-i': {'$eq': issuerHab.pre}, '-a-LEI': {'$eq': 'U6452GAE5C4TVRUY9EIX'}}).sort(['-a-LEI'])
+        assert list(saids) == ['ELDA-hNidE8nsNOYAg993mOLiYAew_eIgicEiK_ilb9Y']
 
 
 def randomLEI():

--- a/tests/app/test_credentialing.py
+++ b/tests/app/test_credentialing.py
@@ -270,28 +270,40 @@ def test_credentialing_ends(helpers, seeder):
 
         parsing.Parser(kvy=agent.kvy, rvy=agent.rvy, tvy=agent.tvy, vry=agent.verifier).parse(ims)
 
+        for said in saids:
+            agent.seeker.index(said)
+
         res = client.simulate_get(f"/identifiers/{hab.name}/credentials")
         assert res.status_code == 404
         assert res.json == {'description': 'name is not a valid reference to an identfier',
                             'title': '404 Not Found'}
 
         res = client.simulate_get(f"/identifiers/test/credentials")
-        assert res.status_code == 400
-        assert res.json == {'description': 'Invalid type None', 'title': '400 Bad Request'}
-
-        res = client.simulate_get(f"/identifiers/test/credentials?type=issued")
-        assert res.status_code == 200
-        assert res.json == []
-
-        res = client.simulate_get(f"/identifiers/test/credentials?type=received")
         assert res.status_code == 200
         assert len(res.json) == 5
 
-        res = client.simulate_get(f"/identifiers/test/credentials?type=received&schema={issuer.LE}")
+        body = json.dumps({'filter': {'-i': issuee}}).encode("utf-8")
+        res = client.simulate_get(f"/identifiers/test/credentials", body=body)
+        assert res.status_code == 200
+        assert res.json == []
+
+        body = json.dumps({'filter': {'-a-i': issuee}}).encode("utf-8")
+        res = client.simulate_get(f"/identifiers/test/credentials", body=body)
+        assert res.status_code == 200
+        assert len(res.json) == 5
+
+        body = json.dumps({'filter': {'-i': hab.pre}}).encode("utf-8")
+        res = client.simulate_get(f"/identifiers/test/credentials", body=body)
+        assert res.status_code == 200
+        assert len(res.json) == 5
+
+        body = json.dumps({'filter': {'-s': {'$eq': issuer.LE}}}).encode("utf-8")
+        res = client.simulate_get(f"/identifiers/test/credentials", body=body)
         assert res.status_code == 200
         assert len(res.json) == 3
 
-        res = client.simulate_get(f"/identifiers/test/credentials?type=received&schema={issuer.QVI}")
+        body = json.dumps({'filter': {'-s': {'$eq': issuer.QVI}}}).encode("utf-8")
+        res = client.simulate_get(f"/identifiers/test/credentials", body=body)
         assert res.status_code == 200
         assert len(res.json) == 2
 


### PR DESCRIPTION
This PR includes a new API for searching for credentials held or issued by AIDs in an Agent.  It uses the SAD path language for referencing fields in a credential and allows for specification of multiple criteria in a dictionary structure keyed by the SAD path reference.  Currently only the $eq and $begins operators are support.  Ascending sort order for all fields is also supported.  

This will be helpful for holders of credentials for sure but the main use case we are trying to address is for credential issuers that need more advance credential management than holders.  So a query to answer the quesiton:

> “Show me all the ECR credentials I issued with LEI ‘xyz’, sorted by date, page size 20 at a time.”

Could be expressed with this API as:

```python
seeker.find(
      {
         '-i': {'$eq': issuerHab.pre},
         '-a-LEI': {'$eq': 'xyz'},
         '-s': {'$eq': 'ECR_SCHEMA_SAID'}
      })
        .sort(['-a-dt']).limit(20)
```

The Seeker object creates indexes in LMDB for all base fields in an ACDC credential and all top level fields with scalar values in the payload of any loaded credential.  In addition, multiple column indexes are created for the following combinations:

- Issuer/Schema
- Issuee/Schema
- Issuer/<Payload Field>
- Issuee/<Payload Field>
- Issuer/Schema/<Payload Field>
- Issuee/Schema/<Payload Field>

All other criteria combinations will use the indexes they can and perform a full table scan as a last resort.  One key limitation is that criteria must be specified in the correct order listed above to make use of the multi-column index.  This should be improved later..

Skip and Limit parameters are provided to enable pagination.  Sort order will determine page order or the lexicographic order or the SAIDs of the credentials.

This API will be exposed through the REST API that is *currently* limited to only listing "my issued" or "my received" credentials. 