### PR TITLE
Fix to Seeker to properly index credential schema with "oneOf".

### DIFF
--- a/src/keria/app/agenting.py
+++ b/src/keria/app/agenting.py
@@ -427,8 +427,6 @@ class SeekerDoer(doing.Doer):
                 print(f"indexing {creder.said}")
                 self.seeker.index(said=creder.said)
 
-            self.cues.append(cue)
-
 
 class Initer(doing.Doer):
     def __init__(self, agentHab, caid):

--- a/src/keria/app/presenting.py
+++ b/src/keria/app/presenting.py
@@ -77,7 +77,7 @@ class PresentationCollectionEnd:
 
         hab = agent.hby.habByName(name)
         if hab is None:
-            raise falcon.HTTPBadRequest(f"Invalid alias {name} for credential presentation")
+            raise falcon.HTTPBadRequest(description=f"Invalid alias {name} for credential presentation")
 
         body = req.get_media()
 

--- a/src/keria/db/basing.py
+++ b/src/keria/db/basing.py
@@ -110,7 +110,7 @@ class Seeker(dbing.LMDBer):
     TailDirPath = "keri/seekdb"
     AltTailDirPath = ".keri/seekdb"
     TempPrefix = "keri_seekdb_"
-    MaxNamedDBs = 50
+    MaxNamedDBs = 500
 
     def __init__(self, db, reger, headDirPath=None, perm=None, reopen=False, **kwa):
         """
@@ -207,8 +207,9 @@ class Seeker(dbing.LMDBer):
 
         properties = schemer.sed["properties"]
         payload = properties['a']
-        if isinstance(payload, list):
-            for p in payload:
+        if "oneOf" in payload:
+            oo = payload["oneOf"]
+            for p in oo:
                 if p["type"] == "object":
                     payload = p
                     break

--- a/src/keria/testing/testing_helper.py
+++ b/src/keria/testing/testing_helper.py
@@ -2,14 +2,13 @@
 """
 Helpers for tests that need KERIA
 """
+import json
 import os
 import shutil
-import json
+from contextlib import contextmanager
 
 import falcon
-import pytest
 from falcon import testing
-from hio.base import doing
 from hio.core import http
 from keri import kering
 from keri.app import keeping, habbing, configing, signing
@@ -20,8 +19,8 @@ from keri.vc import proving
 from keri.vdr import credentialing, verifying
 from keri.vdr import eventing as veventing
 from keri.vdr.credentialing import Regery, Registrar
+
 from keria.app import agenting, indirecting
-from contextlib import contextmanager
 
 WitnessUrls = {
     "wan:tcp": "tcp://127.0.0.1:5632/",
@@ -251,7 +250,6 @@ class Helpers:
         server = http.Server(port=httpPort, app=app)
         httpServerDoer = http.ServerDoer(server=server)
         return httpServerDoer
-
 
     @staticmethod
     def controller():

--- a/src/keria/testing/testing_helper.py
+++ b/src/keria/testing/testing_helper.py
@@ -69,6 +69,70 @@ class DbSeed:
 
     @staticmethod
     def seedSchema(db):
+        sad = {'$id': 'EBfdlu8R27Fbx-ehrqwImnK-8Cm79sqbAQ4MmvEAYqao',
+               '$schema': 'http://json-schema.org/draft-07/schema#', 'title': 'Qualified vLEI Issuer Credential',
+               'description': 'A vLEI Credential issued by GLEIF to Qualified vLEI Issuers which allows the Qualified '
+                              'vLEI Issuers to issue, verify and revoke Legal Entity vLEI Credentials and Legal '
+                              'Entity Official Organizational Role vLEI Credentials',
+               'type': 'object', 'credentialType': 'QualifiedvLEIIssuervLEICredential', 'version': '1.0.0',
+               'properties': {'v': {'description': 'Version', 'type': 'string'},
+                              'd': {'description': 'Credential SAID', 'type': 'string'},
+                              'u': {'description': 'One time use nonce', 'type': 'string'},
+                              'i': {'description': 'GLEIF Issuee AID', 'type': 'string'},
+                              'ri': {'description': 'Credential status registry', 'type': 'string'},
+                              's': {'description': 'Schema SAID', 'type': 'string'}, 'a': {
+                       'oneOf': [{'description': 'Attributes block SAID', 'type': 'string'},
+                                 {'$id': 'ELGgI0fkloqKWREXgqUfgS0bJybP1LChxCO3sqPSFHCj',
+                                  'description': 'Attributes block', 'type': 'object',
+                                  'properties': {'d': {'description': 'Attributes block SAID', 'type': 'string'},
+                                                 'i': {'description': 'QVI Issuee AID', 'type': 'string'},
+                                                 'dt': {'description': 'Issuance date time', 'type': 'string',
+                                                        'format': 'date-time'},
+                                                 'LEI': {'description': 'LEI of the requesting Legal Entity',
+                                                         'type': 'string', 'format': 'ISO 17442'},
+                                                 'gracePeriod': {'description': 'Allocated grace period',
+                                                                 'type': 'integer', 'default': 90}},
+                                  'additionalProperties': False, 'required': ['i', 'dt', 'LEI']}]}, 'r': {
+                       'oneOf': [{'description': 'Rules block SAID', 'type': 'string'},
+                                 {'$id': 'ECllqarpkZrSIWCb97XlMpEZZH3q4kc--FQ9mbkFMb_5', 'description': 'Rules block',
+                                  'type': 'object',
+                                  'properties': {'d': {'description': 'Rules block SAID', 'type': 'string'},
+                                                 'usageDisclaimer': {'description': 'Usage Disclaimer',
+                                                                     'type': 'object', 'properties': {
+                                                         'l': {'description': 'Associated legal language',
+                                                               'type': 'string',
+                                                               'const': 'Usage of a valid, unexpired, and non-revoked '
+                                                                        'vLEI Credential, as defined in the '
+                                                                        'associated Ecosystem Governance Framework, '
+                                                                        'does not assert that the Legal Entity is '
+                                                                        'trustworthy, honest, reputable in its '
+                                                                        'business dealings, safe to do business with, '
+                                                                        'or compliant with any laws or that an '
+                                                                        'implied or expressly intended purpose will '
+                                                                        'be fulfilled.'}}},
+                                                 'issuanceDisclaimer': {'description': 'Issuance Disclaimer',
+                                                                        'type': 'object', 'properties': {
+                                                         'l': {'description': 'Associated legal language',
+                                                               'type': 'string',
+                                                               'const': 'All information in a valid, unexpired, '
+                                                                        'and non-revoked vLEI Credential, as defined '
+                                                                        'in the associated Ecosystem Governance '
+                                                                        'Framework, is accurate as of the date the '
+                                                                        'validation process was complete. The vLEI '
+                                                                        'Credential has been issued to the legal '
+                                                                        'entity or person named in the vLEI '
+                                                                        'Credential as the subject; and the qualified '
+                                                                        'vLEI Issuer exercised reasonable care to '
+                                                                        'perform the validation process set forth in '
+                                                                        'the vLEI Ecosystem Governance Framework.'}}}},
+                                  'additionalProperties': False,
+                                  'required': ['d', 'usageDisclaimer', 'issuanceDisclaimer']}]}},
+               'additionalProperties': False, 'required': ['i', 'ri', 's', 'd']}
+        _, sad = coring.Saider.saidify(sad, label=coring.Saids.dollar)
+        schemer = scheming.Schemer(sed=sad)
+        # NEW: "EBfdlu8R27Fbx-ehrqwImnK-8Cm79sqbAQ4MmvEAYqao"
+        db.schema.pin(schemer.said, schemer)
+
         # OLD: "E1MCiPag0EWlqeJGzDA9xxr1bUSUR4fZXtqHDrwdXgbk"
         sad = {'$id': '',
                '$schema': 'http://json-schema.org/draft-07/schema#', 'title': 'Legal Entity vLEI Credential',

--- a/tests/app/test_basing.py
+++ b/tests/app/test_basing.py
@@ -7,6 +7,7 @@ Testing the database classes
 """
 import random
 
+import pytest
 from keri.app import habbing
 
 from keria.db import basing
@@ -26,6 +27,9 @@ def test_seeker(helpers, seeder, mockHelpingNowUTC):
 
         seeder.seedSchema(issueeHby.db)
         seeder.seedSchema(issuerHby.db)
+
+        with pytest.raises(ValueError):
+            seeker.generateIndexes(said="INVALIDSCHEMASAID")
 
         indexes = seeker.generateIndexes(QVI_SAID)
 
@@ -96,6 +100,9 @@ def test_seeker(helpers, seeder, mockHelpingNowUTC):
 
         # Assure that no knew index tables needed to be created
         assert len(seeker.indexes) == 29
+
+        # test credemtial with "oneOf"
+        seeker.generateIndexes(said="EBfdlu8R27Fbx-ehrqwImnK-8Cm79sqbAQ4MmvEAYqao")
 
         issuer.createRegistry(issuerHab.pre, name="issuer")
 

--- a/tests/app/test_presenting.py
+++ b/tests/app/test_presenting.py
@@ -79,7 +79,8 @@ def test_presentation(helpers, seeder, mockHelpingNowUTC):
         res = client.simulate_post(path=f"/identifiers/BadUser/credentials/{said}/presentations",
                                    body=json.dumps(body).encode("utf-8"))
         assert res.status_code == 400
-        assert res.json == {'title': 'Invalid alias BadUser for credential presentation'}
+        assert res.json == {'description': 'Invalid alias BadUser for credential presentation',
+                            'title': '400 Bad Request'}
 
         res = client.simulate_post(path=f"/identifiers/test/credentials/{said}/presentations",
                                    body=json.dumps(body).encode("utf-8"))


### PR DESCRIPTION
This PR includes several fixes:

* fix the schema parser to properly handle "oneOf" in the "a" block (payload definition) of the schema
* fix to allow for many credential index LMDB databases
* prevents repeated processing of the same credential once saved.