### PR TITLE
Fix resolving OOBIs not in kever

### DIFF
--- a/src/keria/app/agenting.py
+++ b/src/keria/app/agenting.py
@@ -823,7 +823,6 @@ class OOBICollectionEnd:
                 obr.oobialias = body["oobialias"]
 
             agent.hby.db.oobis.pin(keys=(oobi,), val=obr)
-            agent.hby.db.oobis.pin(keys=(oobi,), val=obr)
 
         elif "rpy" in body:
             raise falcon.HTTPNotImplemented(description="'rpy' support not implemented yet")

--- a/src/keria/core/longrunning.py
+++ b/src/keria/core/longrunning.py
@@ -203,10 +203,10 @@ class Monitor:
                 operation.done = False
             elif obr.state == Result.resolved:
                 operation.done = True
-                if obr.cid:
+                try:
                     kever = self.hby.kevers[obr.cid]
                     operation.response = asdict(kever.state())
-                else:
+                except:
                     operation.response = dict(oobi=oobi)
 
             elif obr.state == Result.failed:


### PR DESCRIPTION
That PR fix a`KeyError` error when resolving OOBIs that the `CID` was not on the local never.

Also, I remove a duplicated line. But not sure if it was there on purpose. @pfeairheller ?
