### PR TITLE
Check if witnesses are known

### DIFF
--- a/src/keria/app/aiding.py
+++ b/src/keria/app/aiding.py
@@ -282,6 +282,12 @@ class IdentifierCollectionEnd:
 
             sigers = [coring.Siger(qb64=sig) for sig in sigs]
 
+            if 'b' in icp:
+                for wit in icp['b']:
+                    urls = agent.agentHab.fetchUrls(eid=wit, scheme=kering.Schemes.http)
+                    if not urls and wit not in agent.hby.kevers:
+                        raise falcon.HTTPBadRequest(description=f'unknown witness {wit}')
+
             # client is requesting agent to join multisig group
             if "group" in body:
                 group = body["group"]
@@ -446,6 +452,12 @@ class IdentifierResourceEnd:
         if rot is None:
             raise falcon.HTTPBadRequest(title="invalid rotation",
                                         description=f"required field 'rot' missing from request")
+        
+        if 'ba' in rot:
+            for wit in rot['ba']:
+                urls = agent.agentHab.fetchUrls(eid=wit, scheme=kering.Schemes.http)
+                if not urls and wit not in agent.hby.kevers:
+                    raise falcon.HTTPBadRequest(description=f'unknown witness {wit}')
 
         sigs = body.get("sigs")
         if sigs is None or len(sigs) == 0:

--- a/src/keria/app/aiding.py
+++ b/src/keria/app/aiding.py
@@ -282,6 +282,9 @@ class IdentifierCollectionEnd:
 
             sigers = [coring.Siger(qb64=sig) for sig in sigs]
 
+            if agent.hby.habByName(name) is not None:
+                raise falcon.HTTPBadRequest(title=f"AID with name {name} already incepted")
+
             if 'b' in icp:
                 for wit in icp['b']:
                     urls = agent.agentHab.fetchUrls(eid=wit, scheme=kering.Schemes.http)

--- a/src/keria/app/aiding.py
+++ b/src/keria/app/aiding.py
@@ -287,6 +287,9 @@ class IdentifierCollectionEnd:
                     urls = agent.agentHab.fetchUrls(eid=wit, scheme=kering.Schemes.http)
                     if not urls and wit not in agent.hby.kevers:
                         raise falcon.HTTPBadRequest(description=f'unknown witness {wit}')
+            
+            if 'di' in icp and icp["di"] not in agent.hby.kevers:
+                raise falcon.HTTPBadRequest(description=f'unknown delegator {icp["di"]}')
 
             # client is requesting agent to join multisig group
             if "group" in body:
@@ -459,6 +462,9 @@ class IdentifierResourceEnd:
                 if not urls and wit not in agent.hby.kevers:
                     raise falcon.HTTPBadRequest(description=f'unknown witness {wit}')
 
+        if 'di' in rot and rot["di"] not in agent.hby.kevers:
+            raise falcon.HTTPBadRequest(description=f'unknown delegator {rot["di"]}')
+        
         sigs = body.get("sigs")
         if sigs is None or len(sigs) == 0:
             raise falcon.HTTPBadRequest(title="invalid rotation",

--- a/tests/app/test_agenting.py
+++ b/tests/app/test_agenting.py
@@ -231,6 +231,9 @@ def test_oobi_ends(seeder, helpers):
     with helpers.openKeria() as (agency, agent, app, client), \
             habbing.openHby(name="wes", salt=coring.Salter(raw=b'wess-the-witness').qb64) as wesHby:
         wesHab = wesHby.makeHab(name="wes", transferable=False)
+        # Add witness endpoints
+        url = "http://127.0.0.1:9999"
+        agent.hby.db.locs.put(keys=(wesHab.pre, kering.Schemes.http), val=basing.LocationRecord(url=url))
 
         # Register the identifier endpoint so we can create an AID for the test
         end = aiding.IdentifierCollectionEnd()
@@ -253,7 +256,7 @@ def test_oobi_ends(seeder, helpers):
         assert result.status == falcon.HTTP_404  # Bad role, watcher not supported yet
 
         result = client.simulate_get(path="/oobi/pal?role=witness")
-        assert result.status == falcon.HTTP_404  # Missing OOBI endpoints for witness
+        assert result.status == falcon.HTTP_200
 
         result = client.simulate_get(path="/oobi/pal?role=controller")
         assert result.status == falcon.HTTP_404  # Missing OOBI controller endpoints
@@ -262,7 +265,7 @@ def test_oobi_ends(seeder, helpers):
         url = "http://127.0.0.1:9999"
         agent.hby.db.locs.put(keys=(palPre, kering.Schemes.http), val=basing.LocationRecord(url=url))
         result = client.simulate_get(path="/oobi/pal?role=controller")
-        assert result.status == falcon.HTTP_200  # Missing OOBI controller endpoints
+        assert result.status == falcon.HTTP_200 
         assert result.json == {
             'oobis': ['http://127.0.0.1:9999/oobi/EEkruFP-J0InOD9cYbNLlBxQtkLAbmJPNecSnBzJixP0/controller'],
             'role': 'controller'}

--- a/tests/app/test_aiding.py
+++ b/tests/app/test_aiding.py
@@ -17,6 +17,9 @@ from keri.app.keeping import Algos
 from keri.core import coring, eventing, parsing
 from keri.core.coring import MtrDex
 from keri.peer import exchanging
+from keri.help import helping
+from keri.db import basing
+from keri import kering
 
 from keria.app import aiding, agenting
 
@@ -202,10 +205,8 @@ def test_identifier_collection_end(helpers):
 
         # Try to resubmit and get an error
         res = client.simulate_post(path="/identifiers", body=json.dumps(body))
-        assert res.status_code == 500
-        assert res.json == {'description': 'Already incepted '
-                                           'pre=EHgwVwQT15OJvilVvW57HE4w0-GPs_Stj2OFoAHZSysY.',
-                            'title': '500 Internal Server Error'}
+        assert res.status_code == 400
+        assert res.json == {'title': 'AID with name aid1 already incepted'}
 
         res = client.simulate_get(path="/identifiers")
         assert res.status_code == 200
@@ -241,6 +242,10 @@ def test_identifier_collection_end(helpers):
         assert ss["pidx"] == 1
 
         # Test with witnesses
+        url = "http://127.0.0.1:9999"
+        agent.hby.db.locs.put(keys=("BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha", kering.Schemes.http), val=basing.LocationRecord(url=url))
+        agent.hby.db.locs.put(keys=("BLskRTInXnMxWaGqcpSyMgo0nYbalW99cGZESrz3zapM", kering.Schemes.http), val=basing.LocationRecord(url=url))
+        agent.hby.db.locs.put(keys=("BIKKuvBwpmDVA4Ds-EpL5bt9OqPzWPja2LigFYZN2YfX", kering.Schemes.http), val=basing.LocationRecord(url=url))
         serder, signers = helpers.incept(salt, "signify:aid", pidx=3,
                                          wits=["BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha",
                                                "BLskRTInXnMxWaGqcpSyMgo0nYbalW99cGZESrz3zapM",
@@ -392,10 +397,8 @@ def test_identifier_collection_end(helpers):
 
         # Resubmit to get an error
         res = client.simulate_post(path="/identifiers", body=json.dumps(body))
-        assert res.status_code == 500
-        assert res.json == {'description': 'Already incepted '
-                                           'pre=EGOSjnzaVz4nZ55wk3-SV78WgdaTJZddhom9ZLeNFEd3.',
-                            'title': '500 Internal Server Error'}
+        assert res.status_code == 400
+        assert res.json == {'title': 'AID with name multisig already incepted'}
 
         res = client.simulate_get(path="/identifiers")
         assert res.status_code == 200
@@ -442,8 +445,8 @@ def test_identifier_collection_end(helpers):
 
         # Resubmit and get an error
         res = client.simulate_post(path="/identifiers", body=json.dumps(body))
-        assert res.status_code == 500
-        assert res.json['title'] == '500 Internal Server Error'
+        assert res.status_code == 400
+        assert res.json == {'title': 'AID with name randy1 already incepted'}
 
         res = client.simulate_get(path="/identifiers")
         assert res.status_code == 200


### PR DESCRIPTION
This PR is an attempt to fix the error reported on issue https://github.com/WebOfTrust/keria/issues/54 by checking if the url is in the `hab` or if the obbi was already resolved for new witnesses introduced in a `icp` or a `rot` event. 


@pfeairheller , if you thinks that this is a correct approach, I will add and fix some tests. 