### PR TITLE
chore(docker): Allow cors config via runtime env

### DIFF
--- a/images/keria.dockerfile
+++ b/images/keria.dockerfile
@@ -24,10 +24,8 @@ EXPOSE 3901
 EXPOSE 3902
 EXPOSE 3903
 
-ENV KERI_AGENT_CORS=false
+ENV KERI_AGENT_CORS=${KERI_AGENT_CORS:-false}
 
 RUN mkdir -p /usr/local/var/keri
 
 ENTRYPOINT ["keria", "start",  "--config-file", "demo-witness-oobis", "--config-dir", "./scripts"]
-
-


### PR DESCRIPTION
Allowing CORS config to be overridden from the env is useful to allow for local development against KERIA running in Docker.

Let me know if there's a reason to not do it this way - will still be `false` by default. Thanks