### PR TITLE
fix OperationResourceEnd.on_delete

### DIFF
--- a/src/keria/core/longrunning.py
+++ b/src/keria/core/longrunning.py
@@ -362,7 +362,7 @@ class OperationResourceEnd:
         """
 
         agent = req.context.agent
-        if agent.monitor.get(name) is not None:
+        if agent.monitor.get(name) is None:
             raise falcon.HTTPNotFound(f"long running operation '{name}' not found")
 
         deleted = agent.monitor.rem(name)


### PR DESCRIPTION
Small fix for DELETE /operations/{name}

Was returning 404 Not Found when trying to remove an existing operation