### PR TITLE
split Dockerfile build into two stages

### DIFF
--- a/images/keria.dockerfile
+++ b/images/keria.dockerfile
@@ -1,31 +1,55 @@
+# Builder stage
+FROM python:3.10.13-alpine3.18 as builder
 
-FROM python:3.10.4-alpine3.16
+# Install compilation dependencies
+RUN apk --no-cache add \
+    bash \
+    alpine-sdk \
+    libffi-dev \
+    libsodium \
+    libsodium-dev
 
-RUN apk update
-RUN apk add bash
 SHELL ["/bin/bash", "-c"]
 
-RUN apk add alpine-sdk
-RUN apk add libffi-dev
-RUN apk add libsodium
-RUN apk add libsodium-dev
-
-# Setup Rust for blake3 dependency build
+# Install Rust for blake3 dependency build
 RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
 
-COPY . /keria
 WORKDIR /keria
 
-# Install KERIpy dependencies
-# Must source the Cargo environment for the blake3 library to see the Rust intallation during requirements install
-RUN source "$HOME/.cargo/env" && pip install -r requirements.txt
+RUN python -m venv venv
+ENV PATH=/keria/venv/bin:${PATH}
+RUN pip install --upgrade pip
+
+# Copy in Python dependency files
+COPY requirements.txt setup.py .
+# "src/" dir required for installation of dependencies with setup.py
+RUN mkdir /keria/src
+# Install Python dependencies
+RUN . "$HOME/.cargo/env" && \
+    pip install -r requirements.txt
+
+# Runtime stage
+FROM python:3.10.13-alpine3.18
+
+# Install runtime dependencies
+RUN apk --no-cache add \
+    bash \
+    alpine-sdk \
+    libsodium-dev
+
+WORKDIR /keria
+
+# Copy over compiled dependencies
+COPY --from=builder /keria /keria
+# Copy in KERIA source files - enables near instantaneous builds for source only changes
+RUN mkdir -p /usr/local/var/keri
+ENV KERI_AGENT_CORS=${KERI_AGENT_CORS:-false}
+ENV PATH=/keria/venv/bin:${PATH}
 
 EXPOSE 3901
 EXPOSE 3902
 EXPOSE 3903
 
-ENV KERI_AGENT_CORS=${KERI_AGENT_CORS:-false}
-
-RUN mkdir -p /usr/local/var/keri
+COPY src/ src/
 
 ENTRYPOINT ["keria", "start",  "--config-file", "demo-witness-oobis", "--config-dir", "./scripts"]


### PR DESCRIPTION
One stage for building, one for the runtime. This enables near-instantaneous builds of source only changes