### PR TITLE
Updates to make credential admit fully work

### DIFF
--- a/src/keria/app/agenting.py
+++ b/src/keria/app/agenting.py
@@ -508,8 +508,9 @@ class Admitter(doing.Doer):
                 self.admits.append(msg)
                 return False
 
+            admit, _ = exchanging.cloneMessage(self.hby, said)
             hab = self.hby.habs[msg['pre']]
-            grant, pathed = exchanging.cloneMessage(self.hby, said)
+            grant, pathed = exchanging.cloneMessage(self.hby, admit.ked['p'])
 
             embeds = grant.ked['e']
             acdc = embeds["acdc"]
@@ -518,10 +519,13 @@ class Admitter(doing.Doer):
             # Lets get the latest KEL and Registry if needed
             self.witq.query(hab=self.agentHab, pre=issr)
             if "ri" in acdc:
-                self.witq.telquery(hab=self.agentHab, wits=hab.kevers[issr].wits, ri=acdc["ri"], i=acdc["d"])
+                self.witq.telquery(hab=self.agentHab, pre=issr, ri=acdc["ri"], i=acdc["d"])
 
             for label in ("anc", "iss", "acdc"):
                 ked = embeds[label]
+                if label not in pathed or not pathed[label]:
+                    continue
+
                 sadder = coring.Sadder(ked=ked)
                 ims = bytearray(sadder.raw) + pathed[label]
                 self.psr.parseOne(ims=ims)
@@ -540,8 +544,14 @@ class SeekerDoer(doing.Doer):
             cue = self.cues.popleft()
             if cue["kin"] == "saved":
                 creder = cue["creder"]
-                print(f"indexing {creder.said}")
-                self.seeker.index(said=creder.said)
+                try:
+                    self.seeker.index(said=creder.said)
+                except Exception:
+                    self.cues.append(cue)
+                    return False
+            else:
+                self.cues.append(cue)
+                return False
 
 
 class ExnSeekerDoer(doing.Doer):

--- a/src/keria/app/credentialing.py
+++ b/src/keria/app/credentialing.py
@@ -385,7 +385,7 @@ class CredentialQueryCollectionEnd:
 
         cur = agent.seeker.find(filtr=filtr, sort=sort, skip=skip, limit=limit)
         saids = [coring.Saider(qb64=said) for said in cur]
-        creds = agent.rgy.reger.cloneCreds(saids=saids)
+        creds = agent.rgy.reger.cloneCreds(saids=saids, db=agent.hby.db)
 
         rep.status = falcon.HTTP_200
         rep.content_type = "application/json"
@@ -567,7 +567,7 @@ class CredentialResourceEnd:
             data = CredentialResourceEnd.outputCred(agent.hby, agent.rgy, said)
         else:
             rep.content_type = "application/json"
-            creds = agent.rgy.reger.cloneCreds([coring.Saider(qb64=said)])
+            creds = agent.rgy.reger.cloneCreds([coring.Saider(qb64=said)], db=agent.hby.db)
             if not creds:
                 raise falcon.HTTPNotFound(description=f"credential for said {said} not found.")
 
@@ -659,7 +659,7 @@ class CredentialResourceEnd:
             raise falcon.HTTPNotFound(description=f"revocation against invalid registry SAID {regk}")
         
         try:
-            agent.rgy.reger.cloneCreds([coring.Saider(qb64=said)])
+            agent.rgy.reger.cloneCreds([coring.Saider(qb64=said)], db=agent.hby.db)
         except:
             raise falcon.HTTPNotFound(description=f"credential for said {said} not found.")
 

--- a/src/keria/app/ipexing.py
+++ b/src/keria/app/ipexing.py
@@ -80,6 +80,9 @@ class IpexAdmitCollectonEnd:
         ims = eventing.messagize(serder=serder, sigers=sigers, seal=seal)
 
         # Have to add the atc to the end... this will be Pathed signatures for embeds
+        if not atc:
+            raise falcon.HTTPBadRequest(description=f"attachment missing for ACDC, unable to process request.")
+
         ims.extend(atc.encode("utf-8"))  # add the pathed attachments
 
         # make a copy and parse
@@ -120,6 +123,9 @@ class IpexAdmitCollectonEnd:
         ims = eventing.messagize(serder=serder, sigers=sigers, seal=seal)
 
         # Have to add the atc to the end... this will be Pathed signatures for embeds
+        if 'exn' not in atc or not atc['exn']:
+            raise falcon.HTTPBadRequest(description=f"attachment missing for ACDC, unable to process request.")
+
         ims.extend(atc['exn'].encode("utf-8"))  # add the pathed attachments
 
         # make a copy and parse

--- a/src/keria/db/basing.py
+++ b/src/keria/db/basing.py
@@ -178,6 +178,11 @@ class Seeker(dbing.LMDBer):
     def table(self):
         return self.reger.saved
 
+    def value(self, said):
+        saider = self.reger.saved.get(keys=(said,))
+        creder = self.reger.creds.get(keys=(saider.qb64,))
+        return creder.crd
+
     def saidIter(self):
         return self.reger.saved.getItemIter()
 
@@ -357,6 +362,10 @@ class ExnSeeker(dbing.LMDBer):
     def table(self):
         return self.db.exns
 
+    def value(self, said):
+        serder = self.db.exns.get(keys=(said,))
+        return serder.ked
+
     def saidIter(self):
         for (said,), _ in self.db.exns.getItemIter():
             yield said
@@ -494,9 +503,9 @@ class Cursor:
     def tableScan(self, saids, ops):
         res = []
         for said in saids:
-            creder = self.seeker.table.get(keys=(said,))
+            val = self.seeker.value(said)
             for op in ops:
-                if op(creder):
+                if op(val):
                     res.append(said)
 
         return res
@@ -590,7 +599,7 @@ class Eq:
         if len(args) != 1:
             raise ValueError(f"invalid argument length={len(args)} for equals operator, must be 2")
 
-        val = self.pather.resolve(args[0].crd)
+        val = self.pather.resolve(args[0])
         return val == self.value
 
     @property
@@ -614,7 +623,7 @@ class Begins:
         if len(args) != 1:
             raise ValueError(f"invalid argument length={len(args)} for begins operator, must be 2")
 
-        val = self.pather.resolve(args[0].crd)
+        val = self.pather.resolve(args[0])
         if not isinstance(val, str):
             raise ValueError(f"invalid type={type(args[0])} for begins, must be `str`")
 

--- a/src/keria/db/basing.py
+++ b/src/keria/db/basing.py
@@ -176,7 +176,7 @@ class Seeker(dbing.LMDBer):
 
     @property
     def table(self):
-        return self.reger.creds
+        return self.reger.saved
 
     def saidIter(self):
         return self.reger.saved.getItemIter()
@@ -187,7 +187,6 @@ class Seeker(dbing.LMDBer):
             self.dynIdx.pin(keys=(key,), val=IndexRecord(subkey=key, paths=[key]))
 
     def index(self, said):
-
         if (saider := self.reger.saved.get(keys=(said,))) is None:
             raise ValueError(f"{said} is not a verified credential")
 

--- a/tests/app/test_agenting.py
+++ b/tests/app/test_agenting.py
@@ -21,6 +21,7 @@ from keri.app.agenting import Receiptor
 from keri.core import coring
 from keri.core.coring import MtrDex
 from keri.db import basing
+from keri.vc import proving
 from keri.vdr import credentialing
 
 from keria.app import agenting, aiding
@@ -388,6 +389,7 @@ def test_querier(helpers):
         assert isinstance(qryDoer, querying.QueryDoer) is True
         assert qryDoer.pre == "EI7AkI40M11MS7lkTCb10JC9-nDt-tXwQh44OHAFlv_9"
 
+
 class MockServerTls:
     def __init__(self,  certify, keypath, certpath, cafilepath, port):
         pass
@@ -414,8 +416,29 @@ def test_createHttpServer(monkeypatch):
     assert isinstance(server.servant, MockServerTls)
 
 
+def test_seeker_doer(helpers):
+    with helpers.openKeria() as (agency, agent, app, client):
+        cues = decking.Deck()
+        seeker = agenting.SeekerDoer(agent.seeker, cues)
 
+        creder = proving.Creder(ked={
+            "v": "ACDC10JSON000197_",
+            "d": "EG7ZlUq0Z6a1EUPTM_Qg1LGEg1BWiypHLAekxo8crGzK",
+            "i": "EPbOCiPM7IItIMzMwslKWfPM4tqNIKUCyVVuYJNQHwMB",
+            "ri": "EE5upBEf9JlH0ZCkZwLcNOOQYkiowcF7QBa-SDZg3GLo",
+            "s": "EBfdlu8R27Fbx-ehrqwImnK-8Cm79sqbAQ4MmvEAYqao",
+            "a": {
+                "d": "EH8sB2FZuSYBi6dj8edmPMxS-ZoikR2ova3LAVJvelMe",
+                "i": "ECfRBXooQPoNNQC4i0bkwNfKm-VwV3QsUce14uFfejyj",
+                "dt": "2023-11-07T23:38:05.508152+00:00",
+                "LEI": "5493001KJTIIGC8Y1R17"
+            }
+        })
 
+        assert creder.said == "EG7ZlUq0Z6a1EUPTM_Qg1LGEg1BWiypHLAekxo8crGzK"
 
+        cues.append(dict(kin="saved", creder=creder))
 
-
+        result = seeker.recur()
+        assert result is False
+        assert len(cues) == 1

--- a/tests/app/test_basing.py
+++ b/tests/app/test_basing.py
@@ -103,6 +103,10 @@ def test_seeker(helpers, seeder, mockHelpingNowUTC):
         # Assure that no knew index tables needed to be created
         assert len(seeker.indexes) == 29
 
+        # Test with a bad credential SAID
+        with pytest.raises(ValueError):
+            seeker.index("EZ-i0d8JZAoTNZH3ULaU6JR2nmwyvYAfSVPzhzS6b5CM")
+
         # test credemtial with "oneOf"
         seeker.generateIndexes(said="EBfdlu8R27Fbx-ehrqwImnK-8Cm79sqbAQ4MmvEAYqao")
 
@@ -269,6 +273,9 @@ def test_exnseeker(helpers, seeder, mockHelpingNowUTC):
         msg.extend(atc)
         parsing.Parser().parseOne(ims=msg, exc=exc)
         seeker.index(apply.said)
+
+        saids = seeker.find({})
+        assert list(saids) == [apply.said]
 
         saids = seeker.find({'-i': {'$eq': issuerHab.pre}})
         assert list(saids) == [apply.said]

--- a/tests/app/test_ipexing.py
+++ b/tests/app/test_ipexing.py
@@ -93,6 +93,20 @@ def test_ipex_admit(helpers, mockHelpingNowIso8601):
         data = json.dumps(body).encode("utf-8")
         res = client.simulate_post(path="/identifiers/test/ipex/admit", body=data)
 
+        assert res.status_code == 400
+        assert res.json == {'description': 'attachment missing for ACDC, unable to process request.',
+                            'title': '400 Bad Request'}
+
+        body = dict(
+            exn=exn.ked,
+            sigs=sigs,
+            atc="this is a fake attachment",
+            rec=[pre1]
+        )
+
+        data = json.dumps(body).encode("utf-8")
+        res = client.simulate_post(path="/identifiers/test/ipex/admit", body=data)
+
         assert res.status_code == 202
         assert len(agent.exchanges) == 1
         assert len(agent.admits) == 1

--- a/tests/app/test_ipexing.py
+++ b/tests/app/test_ipexing.py
@@ -80,8 +80,9 @@ def test_ipex_admit(helpers, mockHelpingNowIso8601):
         res = client.simulate_post(path="/identifiers/test/ipex/admit", body=data)
 
         assert res.status_code == 400
-        assert res.json == {'title': 'attempt to send to unknown '
-                                     'AID=EZ-i0d8JZAoTNZH3ULaU6JR2nmwyvYAfSVPzhzS6b5CM'}
+        assert res.json == {'description': 'attempt to send to unknown '
+                                           'AID=EZ-i0d8JZAoTNZH3ULaU6JR2nmwyvYAfSVPzhzS6b5CM',
+                            'title': '400 Bad Request'}
 
         body = dict(
             exn=exn.ked,
@@ -89,6 +90,11 @@ def test_ipex_admit(helpers, mockHelpingNowIso8601):
             atc="",
             rec=[pre1]
         )
+
+        #Bad Sender
+        data = json.dumps(body).encode("utf-8")
+        res = client.simulate_post(path="/identifiers/BAD/ipex/admit", body=data)
+        assert res.status_code == 404
 
         data = json.dumps(body).encode("utf-8")
         res = client.simulate_post(path="/identifiers/test/ipex/admit", body=data)
@@ -108,6 +114,35 @@ def test_ipex_admit(helpers, mockHelpingNowIso8601):
                                        embeds=dict(exn=ims),
                                        dig=dig,
                                        date=helping.nowIso8601())
+
+        # Bad recipient
+        body = dict(
+            exn=exn.ked,
+            sigs=sigs,
+            atc=dict(exn=end.decode("utf-8")),
+            rec=["EZ-i0d8JZAoTNZH3ULaU6JR2nmwyvYAfSVPzhzS6b5CM"]
+        )
+
+        data = json.dumps(body).encode("utf-8")
+        res = client.simulate_post(path="/identifiers/test/ipex/admit", body=data)
+        assert res.status_code == 400
+        assert res.json == {'description': 'attempt to send to unknown '
+                                           'AID=EZ-i0d8JZAoTNZH3ULaU6JR2nmwyvYAfSVPzhzS6b5CM',
+                            'title': '400 Bad Request'}
+
+        # Bad attachments
+        body = dict(
+            exn=exn.ked,
+            sigs=sigs,
+            atc=dict(bad=end.decode("utf-8")),
+            rec=[pre1]
+        )
+
+        data = json.dumps(body).encode("utf-8")
+        res = client.simulate_post(path="/identifiers/test/ipex/admit", body=data)
+        assert res.status_code == 400
+        assert res.json == {'description': 'attachment missing for ACDC, unable to process request.',
+                            'title': '400 Bad Request'}
 
         body = dict(
             exn=exn.ked,

--- a/tests/app/test_ipexing.py
+++ b/tests/app/test_ipexing.py
@@ -93,20 +93,6 @@ def test_ipex_admit(helpers, mockHelpingNowIso8601):
         data = json.dumps(body).encode("utf-8")
         res = client.simulate_post(path="/identifiers/test/ipex/admit", body=data)
 
-        assert res.status_code == 400
-        assert res.json == {'description': 'attachment missing for ACDC, unable to process request.',
-                            'title': '400 Bad Request'}
-
-        body = dict(
-            exn=exn.ked,
-            sigs=sigs,
-            atc="this is a fake attachment",
-            rec=[pre1]
-        )
-
-        data = json.dumps(body).encode("utf-8")
-        res = client.simulate_post(path="/identifiers/test/ipex/admit", body=data)
-
         assert res.status_code == 202
         assert len(agent.exchanges) == 1
         assert len(agent.admits) == 1


### PR DESCRIPTION
This PR includes:

* Moving fix for credential without attachments to the appropriate place.

* Update Seeker to properly query for credentials without a filter.

* Query for TEL events regardless of witnesses.