### PR TITLE
Fix improve accept error message

### DIFF
--- a/src/keria/app/agenting.py
+++ b/src/keria/app/agenting.py
@@ -59,6 +59,8 @@ def setup(name, bran, adminPort, bootPort, base='', httpPort=None, configFile=No
                         'signify-resource', 'signify-timestamp']))
 
     bootServer = createHttpServer(bootPort, bootApp, keypath, certpath, cafilepath)
+    if not bootServer.reopen():
+        raise RuntimeError(f"cannot create boot http server on port {bootPort}")
     bootServerDoer = http.ServerDoer(server=bootServer)
     bootEnd = BootEnd(agency)
     bootApp.add_route("/boot", bootEnd)
@@ -77,6 +79,8 @@ def setup(name, bran, adminPort, bootPort, base='', httpPort=None, configFile=No
     app.resp_options.media_handlers.update(media.Handlers())
 
     adminServer = createHttpServer(adminPort, app, keypath, certpath, cafilepath)
+    if not adminServer.reopen():
+        raise RuntimeError(f"cannot create admin http server on port {adminPort}")
     adminServerDoer = http.ServerDoer(server=adminServer)
 
     doers = [agency, bootServerDoer, adminServerDoer]
@@ -100,6 +104,8 @@ def setup(name, bran, adminPort, bootPort, base='', httpPort=None, configFile=No
         indirecting.loadEnds(agency=agency, app=happ)
 
         server = createHttpServer(httpPort, happ, keypath, certpath, cafilepath)
+        if not server.reopen():
+            raise RuntimeError(f"cannot create local http server on port {httpPort}")
         httpServerDoer = http.ServerDoer(server=server)
         doers.append(httpServerDoer)
 


### PR DESCRIPTION
Fixing issue https://github.com/WebOfTrust/keripy/issues/455 for keria

New startup error messages

```
$ keria start
Traceback (most recent call last):
  File "/home/uroot/.local/bin/keria", line 33, in <module>
    sys.exit(load_entry_point('keria', 'console_scripts', 'keria')())
  File "/home/uroot/keria/src/keria/app/cli/keria.py", line 31, in main
    raise ex
  File "/home/uroot/keria/src/keria/app/cli/keria.py", line 25, in main
    doers = args.handler(args)
  File "/home/uroot/keria/src/keria/app/cli/commands/start.py", line 20, in <lambda>
    parser.set_defaults(handler=lambda args: launch(args))
  File "/home/uroot/keria/src/keria/app/cli/commands/start.py", line 74, in launch
    runAgent(name=args.name,
  File "/home/uroot/keria/src/keria/app/cli/commands/start.py", line 97, in runAgent
    doers.extend(agenting.setup(name=name, base=base, bran=bran,
  File "/home/uroot/keria/src/keria/app/agenting.py", line 63, in setup
    raise RuntimeError(f"cannot create boot http server on port {bootPort}")
RuntimeError: cannot create boot http server on port 3903
```

```
$ keria start -B 33903
Traceback (most recent call last):
  File "/home/uroot/.local/bin/keria", line 33, in <module>
    sys.exit(load_entry_point('keria', 'console_scripts', 'keria')())
  File "/home/uroot/keria/src/keria/app/cli/keria.py", line 31, in main
    raise ex
  File "/home/uroot/keria/src/keria/app/cli/keria.py", line 25, in main
    doers = args.handler(args)
  File "/home/uroot/keria/src/keria/app/cli/commands/start.py", line 20, in <lambda>
    parser.set_defaults(handler=lambda args: launch(args))
  File "/home/uroot/keria/src/keria/app/cli/commands/start.py", line 74, in launch
    runAgent(name=args.name,
  File "/home/uroot/keria/src/keria/app/cli/commands/start.py", line 97, in runAgent
    doers.extend(agenting.setup(name=name, base=base, bran=bran,
  File "/home/uroot/keria/src/keria/app/agenting.py", line 83, in setup
    raise RuntimeError(f"cannot create admin http server on port {adminPort}")
RuntimeError: cannot create admin http server on port 3901
```

```
$ keria start -B 33903 -a 33901
Traceback (most recent call last):
  File "/home/uroot/.local/bin/keria", line 33, in <module>
    sys.exit(load_entry_point('keria', 'console_scripts', 'keria')())
  File "/home/uroot/keria/src/keria/app/cli/keria.py", line 31, in main
    raise ex
  File "/home/uroot/keria/src/keria/app/cli/keria.py", line 25, in main
    doers = args.handler(args)
  File "/home/uroot/keria/src/keria/app/cli/commands/start.py", line 20, in <lambda>
    parser.set_defaults(handler=lambda args: launch(args))
  File "/home/uroot/keria/src/keria/app/cli/commands/start.py", line 74, in launch
    runAgent(name=args.name,
  File "/home/uroot/keria/src/keria/app/cli/commands/start.py", line 97, in runAgent
    doers.extend(agenting.setup(name=name, base=base, bran=bran,
  File "/home/uroot/keria/src/keria/app/agenting.py", line 108, in setup
    raise RuntimeError(f"cannot create local http server on port {httpPort}")
RuntimeError: cannot create local http server on port 3902
```

Error message before the fix

```
$ keria start
The Agency is loaded and waiting for requests...
Traceback (most recent call last):
  File "/home/uroot/.local/bin/keria", line 33, in <module>
    sys.exit(load_entry_point('keria', 'console_scripts', 'keria')())
  File "/home/uroot/keria/src/keria/app/cli/keria.py", line 31, in main
    raise ex
  File "/home/uroot/keria/src/keria/app/cli/keria.py", line 25, in main
    doers = args.handler(args)
  File "/home/uroot/keria/src/keria/app/cli/commands/start.py", line 20, in <lambda>
    parser.set_defaults(handler=lambda args: launch(args))
  File "/home/uroot/keria/src/keria/app/cli/commands/start.py", line 74, in launch
    runAgent(name=args.name,
  File "/home/uroot/keria/src/keria/app/cli/commands/start.py", line 107, in runAgent
    directing.runController(doers=doers, expire=expire)
  File "/home/uroot/keripy/src/keri/app/directing.py", line 665, in runController
    doist.do(doers=doers)
  File "/home/uroot/.local/lib/python3.10/site-packages/hio/base/doing.py", line 156, in do
    self.recur()  # increments .tyme runs recur context
  File "/home/uroot/.local/lib/python3.10/site-packages/hio/base/doing.py", line 275, in recur
    tock = dog.send(self.tyme)  # yielded tock == 0.0 means re-run asap
  File "/home/uroot/.local/lib/python3.10/site-packages/hio/base/doing.py", line 568, in do
    self.done = self.recur(tyme=tyme)
  File "/home/uroot/.local/lib/python3.10/site-packages/hio/core/http/serving.py", line 1359, in recur
    self.server.service()
  File "/home/uroot/.local/lib/python3.10/site-packages/hio/core/http/serving.py", line 846, in service
    self.serviceConnects()
  File "/home/uroot/.local/lib/python3.10/site-packages/hio/core/http/serving.py", line 765, in serviceConnects
    self.servant.serviceConnects()
  File "/home/uroot/.local/lib/python3.10/site-packages/hio/core/tcp/serving.py", line 292, in serviceConnects
    self.serviceAxes()
  File "/home/uroot/.local/lib/python3.10/site-packages/hio/core/tcp/serving.py", line 269, in serviceAxes
    self.serviceAccepts()  # populate .axes
  File "/home/uroot/.local/lib/python3.10/site-packages/hio/core/tcp/serving.py", line 196, in serviceAccepts
    cs, ca = self.accept()
  File "/home/uroot/.local/lib/python3.10/site-packages/hio/core/tcp/serving.py", line 182, in accept
    cs, ca = self.ss.accept()  # virtual connection (socket, host address)
AttributeError: 'NoneType' object has no attribute 'accept'
```