### PR TITLE
Update to match latest CESR 1.1 changes in KERIpy.

### DIFF
--- a/src/keria/app/agenting.py
+++ b/src/keria/app/agenting.py
@@ -22,7 +22,7 @@ from keri.app import configing, keeping, habbing, storing, signaling, oobiing, a
     forwarding, querying, connecting, grouping
 from keri.app.grouping import Counselor
 from keri.app.keeping import Algos
-from keri.core import coring, parsing, eventing, routing
+from keri.core import coring, parsing, eventing, routing, serdering
 from keri.core.coring import Ilks, randomNonce
 from keri.db import dbing
 from keri.db.basing import OobiRecord
@@ -797,7 +797,7 @@ class BootEnd:
         if "icp" not in body:
             raise falcon.HTTPBadRequest(title="invalid inception",
                                         description=f'required field "icp" missing from body')
-        icp = eventing.Serder(ked=body["icp"])
+        icp = serdering.SerderKERI(sad=body["icp"])
 
         if "sig" not in body:
             raise falcon.HTTPBadRequest(title="invalid inception",
@@ -956,7 +956,7 @@ class KeyEventCollectionEnd:
             if not (raw := agent.hby.db.getEvt(key=dgkey)):
                 raise falcon.HTTPInternalServerError(f"Missing event for dig={dig}.")
 
-            serder = coring.Serder(raw=bytes(raw))
+            serder = serdering.SerderKERI(raw=bytes(raw))
             events.append(serder.ked)
 
         rep.status = falcon.HTTP_200

--- a/src/keria/app/aiding.py
+++ b/src/keria/app/aiding.py
@@ -12,7 +12,7 @@ import falcon
 from keri import kering
 from keri.app import habbing
 from keri.app.keeping import Algos
-from keri.core import coring, eventing
+from keri.core import coring, serdering
 from keri.core.coring import Ilks
 from keri.db import dbing
 from keri.help import ogler
@@ -100,7 +100,7 @@ class AgentResourceEnd:
         state = asdict(agent.hby.kevers[agent.caid].state())
         key = dbing.dgKey(state['i'], state['ee']['d'])  # digest key
         msg = agent.hby.db.getEvt(key)
-        eserder = coring.Serder(raw=bytes(msg))
+        eserder = serdering.SerderKERI(raw=bytes(msg))
 
         body = dict(
             agent=asdict(agent.hby.kevers[agent.pre].state()),
@@ -151,7 +151,7 @@ class AgentResourceEnd:
         if "keys" not in body:
             raise falcon.HTTPBadRequest(description="required field 'keys' missing from body")
 
-        rot = coring.Serder(ked=body["rot"])
+        rot = serdering.SerderKERI(sad=body["rot"])
         sigs = body["sigs"]
 
         ctrlHab = agent.hby.habByName(caid, ns="agent")
@@ -209,7 +209,7 @@ class AgentResourceEnd:
 
         ked = body['ixn']
         sigs = body['sigs']
-        ixn = coring.Serder(ked=ked)
+        ixn = serdering.SerderKERI(sad=ked)
         sigers = [coring.Siger(qb64=sig) for sig in sigs]
 
         ctrlHab = agent.hby.habByName(caid, ns="agent")
@@ -308,7 +308,7 @@ class IdentifierCollectionEnd:
             name = httping.getRequiredParam(body, "name")
             sigs = httping.getRequiredParam(body, "sigs")
 
-            serder = coring.Serder(ked=icp)
+            serder = serdering.SerderKERI(sad=icp)
 
             sigers = [coring.Siger(qb64=sig) for sig in sigs]
 
@@ -500,7 +500,7 @@ class IdentifierResourceEnd:
             raise falcon.HTTPBadRequest(title="invalid rotation",
                                         description=f"required field 'sigs' missing from request")
 
-        serder = coring.Serder(ked=rot)
+        serder = serdering.SerderKERI(sad=rot)
         sigers = [coring.Siger(qb64=sig) for sig in sigs]
 
         hab.rotate(serder=serder, sigers=sigers)
@@ -566,7 +566,7 @@ class IdentifierResourceEnd:
             raise falcon.HTTPBadRequest(title="invalid interaction",
                                         description=f"required field 'sigs' missing from request")
 
-        serder = coring.Serder(ked=ixn)
+        serder = serdering.SerderKERI(sad=ixn)
         sigers = [coring.Siger(qb64=sig) for sig in sigs]
 
         hab.interact(serder=serder, sigers=sigers)
@@ -772,7 +772,7 @@ class EndRoleCollectionEnd:
         rpy = httping.getRequiredParam(body, "rpy")
         rsigs = httping.getRequiredParam(body, "sigs")
 
-        rserder = coring.Serder(ked=rpy)
+        rserder = serdering.SerderKERI(sad=rpy)
         data = rserder.ked['a']
         pre = data['cid']
         role = data['role']
@@ -787,7 +787,7 @@ class EndRoleCollectionEnd:
                 description=f"error trying to create end role for unknown local AID {pre}")
 
         rsigers = [coring.Siger(qb64=rsig) for rsig in rsigs]
-        tsg = (hab.kever.prefixer, coring.Seqner(sn=hab.kever.sn), hab.kever.serder.saider, rsigers)
+        tsg = (hab.kever.prefixer, coring.Seqner(sn=hab.kever.sn), coring.Saider(qb64=hab.kever.serder.said), rsigers)
         try:
             agent.hby.rvy.processReply(rserder, tsgs=[tsg])
         except kering.UnverifiedReplyError:
@@ -932,7 +932,7 @@ class ChallengeResourceEnd:
         exn = body["exn"]
         sig = body["sig"]
         recpt = body["recipient"]
-        serder = coring.Serder(ked=exn)
+        serder = serdering.SerderKERI(sad=exn)
 
         ims = bytearray(serder.raw)
         ims.extend(sig.encode("utf-8"))

--- a/src/keria/app/grouping.py
+++ b/src/keria/app/grouping.py
@@ -8,7 +8,8 @@ import json
 
 import falcon
 from keri.app import habbing
-from keri.core import coring, eventing
+from keri.core import coring, eventing, serdering
+from keri.kering import SerializeError
 
 from keria.core import httping, longrunning
 
@@ -50,7 +51,7 @@ class MultisigRequestCollectionEnd:
 
         # grab all of the required parameters
         ked = httping.getRequiredParam(body, "exn")
-        serder = coring.Serder(ked=ked)
+        serder = serdering.SerderKERI(sad=ked)
         sigs = httping.getRequiredParam(body, "sigs")
         atc = httping.getRequiredParam(body, "atc")
 
@@ -131,13 +132,13 @@ class MultisigJoinCollectionEnd:
 
         hab = agent.hby.joinSignifyGroupHab(gid, name=name, mhab=mhab, smids=smids, rmids=rmids)
         try:
-            hab.make(serder=coring.Serder(ked=rot), sigers=sigers)
+            hab.make(serder=serdering.SerderKERI(sad=rot), sigers=sigers)
             agent.inceptGroup(pre=gid, mpre=mhab.pre, verfers=verfers, digers=digers)
-        except ValueError as e:
+        except (ValueError, SerializeError) as e:
             agent.hby.deleteHab(name=name)
             raise falcon.HTTPBadRequest(description=f"{e.args[0]}")
 
-        serder = coring.Serder(ked=rot)
+        serder = serdering.SerderKERI(sad=rot)
         agent.groups.append(dict(pre=hab.pre, serder=serder, sigers=sigers, smids=smids, rmids=rmids))
         op = agent.monitor.submit(serder.pre, longrunning.OpTypes.group, metadata=dict(sn=0))
 
@@ -184,7 +185,7 @@ class MultisigRequestResourceEnd:
 
         for d in exns:
             exn = d['exn']
-            serder = coring.Serder(ked=exn)
+            serder = serdering.SerderKERI(sad=exn)
 
             route = serder.ked['r']
             payload = serder.ked['a']

--- a/src/keria/app/ipexing.py
+++ b/src/keria/app/ipexing.py
@@ -8,7 +8,7 @@ services and endpoint for IPEX message managements
 import json
 
 import falcon
-from keri.core import coring, eventing
+from keri.core import coring, eventing, serdering
 
 from keria.core import httping
 
@@ -72,7 +72,7 @@ class IpexAdmitCollectionEnd:
                 raise falcon.HTTPBadRequest(description=f"attempt to send to unknown AID={recp}")
 
         # use that data to create th Serder and Sigers for the exn
-        serder = coring.Serder(ked=ked)
+        serder = serdering.SerderKERI(sad=ked)
         sigers = [coring.Siger(qb64=sig) for sig in sigs]
 
         # Now create the stream to send, need the signer seal
@@ -106,14 +106,14 @@ class IpexAdmitCollectionEnd:
             raise falcon.HTTPBadRequest(description=f"attachment missing for ACDC, unable to process request.")
 
         holder = admit['a']['i']
-        serder = coring.Serder(ked=admit)
+        serder = serdering.SerderKERI(sad=admit)
         ims = bytearray(serder.raw) + atc['exn'].encode("utf-8")
         agent.hby.psr.parseOne(ims=ims)
         agent.exchanges.append(dict(said=serder.said, pre=hab.pre, rec=holder, topic="credential"))
         agent.admits.append(dict(said=admit['d'], pre=hab.pre))
 
         # use that data to create th Serder and Sigers for the exn
-        serder = coring.Serder(ked=ked)
+        serder = serdering.SerderKERI(sad=ked)
         sigers = [coring.Siger(qb64=sig) for sig in sigs]
 
         # Now create the stream to send, need the signer seal
@@ -181,7 +181,7 @@ class IpexGrantCollectionEnd:
                 raise falcon.HTTPBadRequest(description=f"attempt to send to unknown AID={recp}")
 
         # use that data to create th Serder and Sigers for the exn
-        serder = coring.Serder(ked=ked)
+        serder = serdering.SerderKERI(sad=ked)
         sigers = [coring.Siger(qb64=sig) for sig in sigs]
 
         # Now create the stream to send, need the signer seal
@@ -215,14 +215,14 @@ class IpexGrantCollectionEnd:
             raise falcon.HTTPBadRequest(description=f"attachment missing for ACDC, unable to process request.")
 
         holder = grant['a']['i']
-        serder = coring.Serder(ked=grant)
+        serder = serdering.SerderKERI(sad=grant)
         ims = bytearray(serder.raw) + atc['exn'].encode("utf-8")
         agent.hby.psr.parseOne(ims=ims)
         agent.exchanges.append(dict(said=serder.said, pre=hab.pre, rec=holder, topic="credential"))
         agent.grants.append(dict(said=grant['d'], pre=hab.pre))
 
         # use that data to create th Serder and Sigers for the exn
-        serder = coring.Serder(ked=ked)
+        serder = serdering.SerderKERI(sad=ked)
         sigers = [coring.Siger(qb64=sig) for sig in sigs]
 
         # Now create the stream to send, need the signer seal

--- a/src/keria/core/longrunning.py
+++ b/src/keria/core/longrunning.py
@@ -12,7 +12,7 @@ import falcon
 from dataclasses_json import dataclass_json
 from keri import kering
 from keri.app.oobiing import Result
-from keri.core import eventing, coring
+from keri.core import eventing, coring, serdering
 from keri.db import dbing, koming
 from keri.help import helping
 
@@ -178,7 +178,7 @@ class Monitor:
 
             if len(wigs) >= kever.toader.num:
                 evt = self.hby.db.getEvt(dbing.dgKey(pre=kever.prefixer.qb64, dig=bytes(sdig)))
-                serder = coring.Serder(raw=bytes(evt))
+                serder = serdering.SerderKERI(raw=bytes(evt))
                 operation.done = True
                 operation.response = serder.ked
 
@@ -230,7 +230,7 @@ class Monitor:
 
             if self.swain.complete(kever.prefixer, seqner):
                 evt = self.hby.db.getEvt(dbing.dgKey(pre=kever.prefixer.qb64, dig=bytes(sdig)))
-                serder = coring.Serder(raw=bytes(evt))
+                serder = serdering.SerderKERI(raw=bytes(evt))
 
                 operation.done = True
                 operation.response = serder.ked
@@ -247,7 +247,7 @@ class Monitor:
             if self.counselor.complete(prefixer, seqner):
                 sdig = self.hby.db.getKeLast(key=dbing.snKey(pre=op.oid, sn=seqner.sn))
                 evt = self.hby.db.getEvt(dbing.dgKey(pre=prefixer.qb64, dig=bytes(sdig)))
-                serder = coring.Serder(raw=bytes(evt))
+                serder = serdering.SerderKERI(raw=bytes(evt))
 
                 operation.done = True
                 operation.response = serder.ked

--- a/src/keria/db/basing.py
+++ b/src/keria/db/basing.py
@@ -181,7 +181,7 @@ class Seeker(dbing.LMDBer):
     def value(self, said):
         saider = self.reger.saved.get(keys=(said,))
         creder = self.reger.creds.get(keys=(saider.qb64,))
-        return creder.crd
+        return creder.sad
 
     def saidIter(self):
         return self.reger.saved.getItemIter()
@@ -209,7 +209,7 @@ class Seeker(dbing.LMDBer):
             values = []
             for path in idx.paths:
                 pather = coring.Pather(qb64=path)
-                values.append(pather.resolve(creder.crd))
+                values.append(pather.resolve(creder.sad))
 
             value = "".join(values)
             db.add(keys=(value,), val=saider)

--- a/src/keria/peer/exchanging.py
+++ b/src/keria/peer/exchanging.py
@@ -7,7 +7,7 @@ keria.app.exchanging module
 import json
 
 import falcon
-from keri.core import coring, eventing
+from keri.core import coring, eventing, serdering
 from keri.peer import exchanging
 
 from keria.core import httping
@@ -57,7 +57,7 @@ class ExchangeCollectionEnd:
                 raise falcon.HTTPBadRequest(f"attempt to send to unknown AID={recp}")
 
         # use that data to create th Serder and Sigers for the exn
-        serder = coring.Serder(ked=ked)
+        serder = serdering.SerderKERI(sad=ked)
         sigers = [coring.Siger(qb64=sig) for sig in sigs]
 
         # Now create the stream to send, need the signer seal

--- a/src/keria/testing/testing_helper.py
+++ b/src/keria/testing/testing_helper.py
@@ -12,7 +12,7 @@ from falcon import testing
 from hio.core import http
 from keri import kering
 from keri.app import keeping, habbing, configing, signing
-from keri.core import coring, eventing, parsing, routing, scheming
+from keri.core import coring, eventing, parsing, routing, scheming, serdering
 from keri.core.coring import MtrDex
 from keri.core.eventing import SealEvent
 from keri.help import helping
@@ -458,7 +458,7 @@ class Helpers:
         res = client.simulate_post(path=f"/identifiers/{name}/endroles", json=body)
         op = res.json
         ked = op["response"]
-        serder = coring.Serder(ked=ked)
+        serder = serdering.SerderKERI(sad=ked)
         assert serder.raw == rpy.raw
 
     @staticmethod
@@ -587,7 +587,7 @@ class Issuer:
         rseal = dict(i=rseal.i, s=rseal.s, d=rseal.d)
         anc = hab.interact(data=[rseal])
 
-        aserder = coring.Serder(raw=bytes(anc))
+        aserder = serdering.SerderKERI(raw=bytes(anc))
         self.registrar.incept(iserder=registry.vcp, anc=aserder)
 
         # Process escrows to clear event
@@ -620,7 +620,7 @@ class Issuer:
         rseal = dict(i=rseal.i, s=rseal.s, d=rseal.d)
 
         anc = issuer.interact(data=[rseal])
-        aserder = coring.Serder(raw=anc)
+        aserder = serdering.SerderKERI(raw=anc)
         self.registrar.issue(creder=creder, iserder=iserder, anc=aserder)
 
         prefixer = coring.Prefixer(qb64=iserder.pre)
@@ -661,7 +661,7 @@ class Issuer:
         rseal = dict(i=rseal.i, s=rseal.s, d=rseal.d)
 
         anc = issuer.interact(data=[rseal])
-        aserder = coring.Serder(raw=anc)
+        aserder = serdering.SerderKERI(raw=anc)
         self.registrar.issue(creder=creder, iserder=iserder, anc=aserder)
 
         prefixer = coring.Prefixer(qb64=iserder.pre)

--- a/tests/app/test_agenting.py
+++ b/tests/app/test_agenting.py
@@ -18,7 +18,7 @@ from hio.help import decking
 from keri import kering
 from keri.app import habbing, configing, oobiing, querying
 from keri.app.agenting import Receiptor
-from keri.core import coring
+from keri.core import coring, serdering
 from keri.core.coring import MtrDex
 from keri.db import basing
 from keri.vc import proving
@@ -422,7 +422,7 @@ def test_seeker_doer(helpers):
         cues = decking.Deck()
         seeker = agenting.SeekerDoer(agent.seeker, cues)
 
-        creder = proving.Creder(ked={
+        creder = serdering.SerderACDC(sad={
             "v": "ACDC10JSON000197_",
             "d": "EG7ZlUq0Z6a1EUPTM_Qg1LGEg1BWiypHLAekxo8crGzK",
             "i": "EPbOCiPM7IItIMzMwslKWfPM4tqNIKUCyVVuYJNQHwMB",

--- a/tests/app/test_aiding.py
+++ b/tests/app/test_aiding.py
@@ -14,7 +14,7 @@ import falcon
 from falcon import testing
 from keri.app import habbing, keeping, configing
 from keri.app.keeping import Algos
-from keri.core import coring, eventing, parsing
+from keri.core import coring, eventing, parsing, serdering
 from keri.core.coring import MtrDex
 from keri.db.basing import LocationRecord
 from keri.peer import exchanging
@@ -86,7 +86,7 @@ def test_endrole_ends(helpers):
         res = client.simulate_post(path=f"/identifiers/user1/endroles", json=body)
         op = res.json
         ked = op["response"]
-        serder = coring.Serder(ked=ked)
+        serder = serdering.SerderKERI(sad=ked)
         assert serder.raw == rpy.raw
 
         keys = (recp, 'agent', agent.agentHab.pre)
@@ -795,7 +795,7 @@ def test_identifier_collection_end(helpers):
         assert op['name'] == "delegation.EFt8G8gkCJ71e4amQaRUYss0BDK4pUpzKelEIr3yZ1D0"
 
         # try unknown delegator
-        delpre = "EHgwVwQT15OJvilVvW57HE4w0-GPs_Stj2OFoAHUNKN"
+        delpre = "EHgwVwQT15OJvilVvW57HE4w0-GPs_Stj2OFoAHUNKNx"
         serder, signers = helpers.incept(salt, "signify:aid", pidx=0, delpre=delpre)
 
         salter = coring.Salter(raw=salt)
@@ -815,7 +815,7 @@ def test_identifier_collection_end(helpers):
         res = client.simulate_post(path="/identifiers", body=json.dumps(body))
         assert res.status_code == 400
         assert res.json == {'title': '400 Bad Request',
-                            'description': "unknown delegator EHgwVwQT15OJvilVvW57HE4w0-GPs_Stj2OFoAHUNKN"}
+                            'description': "unknown delegator EHgwVwQT15OJvilVvW57HE4w0-GPs_Stj2OFoAHUNKNx"}
 
     # Test extern keys for HSM integration, only initial tests, work still needed
     with helpers.openKeria() as (agency, agent, app, client):
@@ -934,7 +934,7 @@ def test_challenge_ends(helpers):
         assert op["done"] is False
 
         # Set the signed result to True so it verifies
-        agent.hby.db.reps.add(keys=(aid['i'],), val=exn.saider)
+        agent.hby.db.reps.add(keys=(aid['i'],), val=coring.Saider(qb64=exn.said))
         agent.hby.db.exns.pin(keys=(exn.said,), val=exn)
 
         result = client.simulate_post(path=f"/challenges/pal/verify/{aid['i']}", body=b)
@@ -1225,7 +1225,7 @@ def test_oobi_ends(helpers):
         # Create an AID to test against
         salt = b'0123456789abcdef'
         op = helpers.createAid(client, "pal", salt)
-        iserder = coring.Serder(ked=op["response"])
+        iserder = serdering.SerderKERI(sad=op["response"])
         assert iserder.pre == "EHgwVwQT15OJvilVvW57HE4w0-GPs_Stj2OFoAHZSysY"
 
         # Test before endroles are added
@@ -1240,7 +1240,7 @@ def test_oobi_ends(helpers):
         res = client.simulate_post(path=f"/identifiers/pal/endroles", json=body)
         op = res.json
         ked = op["response"]
-        serder = coring.Serder(ked=ked)
+        serder = serdering.SerderKERI(sad=ked)
         assert serder.raw == rpy.raw
 
         # not valid calls
@@ -1309,7 +1309,7 @@ def test_oobi_ends(helpers):
         res = client.simulate_post(path=f"/identifiers/pal/endroles", json=body)
         op = res.json
         ked = op["response"]
-        serder = coring.Serder(ked=ked)
+        serder = serdering.SerderKERI(sad=ked)
         assert serder.raw == rpy.raw
 
         res = client.simulate_get("/identifiers/pal/oobis?role=mailbox")
@@ -1330,19 +1330,19 @@ def test_rpy_escow_end(helpers):
 
         rpy1 = helpers.endrole("EHgwVwQT15OJvilVvW57HE4w0-GPs_Stj2OFoAHZSysY",
                                "ECL8abFVW_0RTZXFhiiA4rkRobNvjTfJ6t-T8UdBRV1e")
-        agent.hby.db.rpes.add(keys=("/end/role",), val=rpy1.saider)
+        agent.hby.db.rpes.add(keys=("/end/role",), val=coring.Saider(qb64=rpy1.said))
         agent.hby.db.rpys.put(keys=(rpy1.said,), val=rpy1)
 
         rpy2 = helpers.endrole("EHgwVwQT15OJvilVvW57HE4w0-GPs_Stj2OFoAHZSysY",
                                "ECL8abFVW_0RTZXFhiiA4rkRobNvjTfJ6t-T8UdBRV1e",
                                role=kering.Roles.controller)
-        agent.hby.db.rpes.add(keys=("/end/role",), val=rpy2.saider)
+        agent.hby.db.rpes.add(keys=("/end/role",), val=coring.Saider(qb64=rpy2.said))
         agent.hby.db.rpys.put(keys=(rpy2.said,), val=rpy2)
 
         rpy3 = helpers.endrole("EHgwVwQT15OJvilVvW57HE4w0-GPs_Stj2OFoAHZSysY",
                                "BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha",
                                role=kering.Roles.witness)
-        agent.hby.db.rpes.add(keys=("/end/role",), val=rpy3.saider)
+        agent.hby.db.rpes.add(keys=("/end/role",), val=coring.Saider(qb64=rpy3.said))
         agent.hby.db.rpys.put(keys=(rpy3.said,), val=rpy3)
 
         res = client.simulate_get(path="/escrows/rpy?route=/end/role")

--- a/tests/app/test_credentialing.py
+++ b/tests/app/test_credentialing.py
@@ -11,7 +11,7 @@ import falcon
 from falcon import testing
 from hio.base import doing
 from keri.app import habbing
-from keri.core import scheming, coring, parsing
+from keri.core import scheming, coring, parsing, serdering
 from keri.core.eventing import TraitCodex, SealEvent
 from keri.vc import proving
 from keri.vdr import eventing
@@ -238,7 +238,7 @@ def test_issue_credential(helpers, seeder):
             iss=regser.ked,
             ixn=serder.ked,
             sigs=sigers,
-            acdc=creder.ked,
+            acdc=creder.sad,
             csigs=csigers,
             path=pather.qb64)
         
@@ -251,7 +251,7 @@ def test_issue_credential(helpers, seeder):
         op = result.json
 
         assert 'ced' in op['metadata']
-        assert op['metadata']['ced'] == creder.ked
+        assert op['metadata']['ced'] == creder.sad
 
         while not agent.credentialer.complete(creder.said):
             doist.recur(deeds=deeds)
@@ -297,7 +297,7 @@ def test_credentialing_ends(helpers, seeder):
         rseal = dict(i=rseal.i, s=rseal.s, d=rseal.d)
         anc = hab.interact(data=[rseal])
 
-        aserder = coring.Serder(raw=bytes(anc))
+        aserder = serdering.SerderKERI(raw=bytes(anc))
         registrar.incept(iserder=registry.vcp, anc=aserder)
 
         assert registry.regk == "EACehJRd0wfteUAJgaTTJjMSaQqWvzeeHqAMMqxuqxU4"
@@ -459,7 +459,7 @@ def test_revoke_credential(helpers, seeder):
             iss=regser.ked,
             ixn=serder.ked,
             sigs=sigers,
-            acdc=creder.ked,
+            acdc=creder.sad,
             csigs=csigers,
             path=pather.qb64)
         
@@ -472,7 +472,7 @@ def test_revoke_credential(helpers, seeder):
         op = result.json
 
         assert 'ced' in op['metadata']
-        assert op['metadata']['ced'] == creder.ked
+        assert op['metadata']['ced'] == creder.sad
 
         while not agent.credentialer.complete(creder.said):
             doist.recur(deeds=deeds)
@@ -491,7 +491,7 @@ def test_revoke_credential(helpers, seeder):
         assert res.json[0]['sad']['d'] == creder.said
         assert res.json[0]['status']['s'] == "0"
 
-        regser = eventing.revoke(vcdig=creder.said, regk=registry["regk"], dig = regser.said, dt=dt)
+        regser = eventing.revoke(vcdig=creder.said, regk=registry["regk"], dig=regser.said, dt=dt)
         anchor = dict(i=regser.ked['i'], s=regser.ked["s"], d=regser.said)
         serder, sigers = helpers.interact(pre=iaid, bran=isalt, pidx=0, ridx=0, dig=serder.said, sn='3', data=[anchor])
 
@@ -508,22 +508,29 @@ def test_revoke_credential(helpers, seeder):
         assert res.status_code == 404
         assert res.json == {'description': f"credential for said {regser.said} not found.",
                             'title': '404 Not Found'}
-        
+
+        badrev = regser.ked.copy()
+        badrev["ri"] = "EIVtei3pGKGUw8H2Ri0h1uOevtSA6QGAq5wifbtHIaNI"
+        _, sad = coring.Saider.saidify(badrev)
+
         badbody = dict(
-            rev=regser.ked.copy(),
+            rev=sad,
             ixn=serder.ked,
             sigs=sigers)
-        badbody["rev"]["ri"] = "badregk"
         res = client.simulate_delete(path=f"/identifiers/issuer/credentials/{creder.said}", body=json.dumps(badbody).encode("utf-8"))
         assert res.status_code == 404
-        assert res.json == {'description': f"revocation against invalid registry SAID badregk",
+        assert res.json == {'description': 'revocation against invalid registry SAID '
+                                           'EIVtei3pGKGUw8H2Ri0h1uOevtSA6QGAq5wifbtHIaNI',
                             'title': '404 Not Found'}
-        
+
+        badrev = regser.ked.copy()
+        badrev["i"] = "EMgdjM1qALk3jlh4P2YyLRSTcjSOjLXD3e_uYpxbdbg6"
+        _, sad = coring.Saider.saidify(badrev)
+
         badbody = dict(
-            rev=regser.ked.copy(),
+            rev=sad,
             ixn=serder.ked,
             sigs=sigers)
-        badbody["rev"]["i"] = "EMgdjM1qALk3jlh4P2YyLRSTcjSOjLXD3e_uYpxbdbg6"
         res = client.simulate_delete(path=f"/identifiers/issuer/credentials/{creder.said}", body=json.dumps(badbody).encode("utf-8"))
         assert res.status_code == 400
         assert res.json == {'description': "invalid revocation event.",

--- a/tests/app/test_grouping.py
+++ b/tests/app/test_grouping.py
@@ -138,7 +138,7 @@ def test_multisig_request_ends(helpers):
 
         # Fudge this because we won't be able to save a message from someone else:
         esaid = exn.ked['e']['d']
-        agent.hby.db.meids.add(keys=(esaid,), val=exn.saider)
+        agent.hby.db.meids.add(keys=(esaid,), val=coring.Saider(qb64=exn.said))
 
         res = client.simulate_get(path=f"/multisig/request/BADSAID")
         assert res.status_code == 404
@@ -230,7 +230,7 @@ def test_join(helpers, monkeypatch):
 
         res = client.simulate_post("/identifiers/mms/multisig/join", json=body)
         assert res.status_code == 400
-        assert res.json == {'description': "Missing or empty version string in key event dict = {'k': "
+        assert res.json == {'description': "Missing version string field in {'k': "
                                            "['DNp1NUbUEgei6KOlIfT5evXueOi3TDFZkUXgJQWNvegf', "
                                            "'DLsXs0-dxqrM4hugX7NkfZUzET13ngfRhWC9GgXvX9my', "
                                            "'DE2W_yGSF-m44vXPuQ5_wHJ9EK59N-OIT3hABgdAcCKs', "
@@ -242,7 +242,7 @@ def test_join(helpers, monkeypatch):
                                            "'EBFg-5SGDCv5YfwpkArWRBdTxNRUXU8uVcDKNzizOQZc', "
                                            "'EBmW2bXbgsP3HITwW3FmITzAb3wVmHlxCusZ46vgGgP5', "
                                            "'EL4RpdS2Atb2Syu5xLdpz9CcNNYoFUUDlLHxHD09vcgh', "
-                                           "'EAiBVuuhCZrgckeHc9KzROVGJpmGbk2-e1B25GaeRrJs']}",
+                                           "'EAiBVuuhCZrgckeHc9KzROVGJpmGbk2-e1B25GaeRrJs']}.",
                             'title': '400 Bad Request'}
 
         body['rot'] = {

--- a/tests/app/test_indirecting.py
+++ b/tests/app/test_indirecting.py
@@ -8,7 +8,7 @@ Testing the Mark II Agent
 import falcon.testing
 from hio.help import Hict
 from keri.app import habbing, httping
-from keri.core import coring
+from keri.core import coring, serdering
 from keri.core.coring import randomNonce, MtrDex
 from keri.vdr import eventing
 from keria.end import ending
@@ -34,7 +34,7 @@ def test_indirecting(helpers):
 
         hab = hby.makeHab("test")
         icp = hab.makeOwnInception()
-        serder = coring.Serder(raw=icp)
+        serder = serdering.SerderKERI(raw=icp)
         atc = icp[:serder.size]
 
         client = falcon.testing.TestClient(app)
@@ -69,7 +69,7 @@ def test_indirecting(helpers):
 
         # Regular (non-mbx) query messages accepted
         msg = hab.query(pre=hab.pre, src=hab.pre, route="ksn")
-        serder = coring.Serder(raw=msg)
+        serder = serdering.SerderKERI(raw=msg)
         atc = msg[:serder.size]
 
         headers = Hict([
@@ -85,7 +85,7 @@ def test_indirecting(helpers):
 
         # Mailbox query not found
         msg = hab.query(pre=hab.pre, src=hab.pre, route="mbx")
-        serder = coring.Serder(raw=msg)
+        serder = serdering.SerderKERI(raw=msg)
         atc = msg[:serder.size]
 
         headers = Hict([
@@ -159,9 +159,4 @@ def test_indirecting(helpers):
 
         result = client.simulate_get(path="/oobi/EIaGMMWJFPmtXznY1IIiKDIrg-vIyge6mBl2QV8dDjI3")
         assert result.status == falcon.HTTP_404 
-
-
-
-
-
 

--- a/tests/end/test_ending.py
+++ b/tests/end/test_ending.py
@@ -6,7 +6,7 @@ keria.app.ending module
 Testing the Mark II Agent Grouping endpoints
 
 """
-from keri.core import coring
+from keri.core import serdering
 
 from keria.app import aiding
 from keria.end import ending
@@ -54,7 +54,7 @@ def test_oobi_end(helpers):
         res = client.simulate_post(path=f"/identifiers/aid1/endroles", json=body)
         op = res.json
         ked = op["response"]
-        serder = coring.Serder(ked=ked)
+        serder = serdering.SerderKERI(sad=ked)
         assert serder.raw == rpy.raw
 
         res = client.simulate_get(path=f"/oobi")

--- a/tests/peer/test_exchanging.py
+++ b/tests/peer/test_exchanging.py
@@ -9,7 +9,7 @@ Testing the Mark II Agent Grouping endpoints
 import json
 
 from hio.base import doing
-from keri.core import coring, eventing
+from keri.core import eventing, serdering
 from keri.peer.exchanging import exchange
 
 from keria.app import aiding
@@ -125,11 +125,11 @@ def test_exchange_end(helpers):
         assert len(res.json) == 2
 
         ked = res.json[0]['exn']
-        serder = coring.Serder(ked=ked)
+        serder = serdering.SerderKERI(sad=ked)
         assert serder.said == cexn.said
 
         ked = res.json[1]['exn']
-        serder = coring.Serder(ked=ked)
+        serder = serdering.SerderKERI(sad=ked)
         assert serder.said == exn.said
 
         body = json.dumps({'filter': {'-i': pre}, 'sort': ['-dt'], 'skip': 1, "limit": 1}).encode("utf-8")
@@ -138,12 +138,12 @@ def test_exchange_end(helpers):
         assert len(res.json) == 1
 
         ked = res.json[0]['exn']
-        serder = coring.Serder(ked=ked)
+        serder = serdering.SerderKERI(sad=ked)
         assert serder.said == exn.said
 
         res = client.simulate_get(f"/exchanges/{exn.said}")
         assert res.status_code == 200
-        serder = coring.Serder(ked=res.json['exn'])
+        serder = serdering.SerderKERI(sad=res.json['exn'])
         assert serder.said == exn.said
 
         payload = dict(


### PR DESCRIPTION
This PR catches KERIA up to the latest CESR 1.1 related changes pushed to KERIpy.  This includes changing all references to Serder to SerderKERI and Creder to SerderACDC as well as updates to test to account for the increased finicky nature of the Serder**** classes (pedantic field and SAID checking).

All unit test pass but these changes have not been vetted against current Signify clients.  That's next.