### PR TITLE
fix: key states query operation internal server error (ksn.ked does not exist)

### DIFF
--- a/src/keria/core/longrunning.py
+++ b/src/keria/core/longrunning.py
@@ -279,7 +279,7 @@ class Monitor:
                         ksn = self.hby.db.ksns.get(keys=(saider.qb64,))
                         break
 
-                    if ksn and ksn.ked['d'] == kever.serder.said:
+                    if ksn and ksn.d == kever.serder.said:
                         operation.done = True
                         operation.response = asdict(kever.state())
                     else:


### PR DESCRIPTION
Closes #150 

I could not find any tests for this feature to update and currently do not have time to write something from scratch. Creating the PR anyway and you can decide if you want to takeover, wait for the tests or just merge it.

We are still not able to retrieve the updated state by using the key states query endpoint though. But that is another issue.