### PR TITLE
Update references to Seq No to use hex string instead of int

### DIFF
--- a/src/keria/app/agenting.py
+++ b/src/keria/app/agenting.py
@@ -705,7 +705,8 @@ class Querier(doing.DoDoer):
             pre = msg["pre"]
 
             if "sn" in msg:
-                seqNoDo = querying.SeqNoQuerier(hby=self.hby, hab=self.agentHab, pre=pre, sn=msg["sn"])
+                sn = int(msg['sn'], 16)
+                seqNoDo = querying.SeqNoQuerier(hby=self.hby, hab=self.agentHab, pre=pre, sn=sn)
                 self.extend([seqNoDo])
             elif "anchor" in msg:
                 pass

--- a/src/keria/core/longrunning.py
+++ b/src/keria/core/longrunning.py
@@ -286,7 +286,8 @@ class Monitor:
             else:
                 kever = self.hby.kevers[op.oid]
                 if "sn" in op.metadata:
-                    if kever.sn >= op.metadata["sn"]:
+                    sn = int(op.metadata['sn'], 16)
+                    if kever.sn >= sn:
                         operation.done = True
                         operation.response = asdict(kever.state())
                     else:
@@ -304,7 +305,7 @@ class Monitor:
                         ksn = self.hby.db.ksns.get(keys=(saider.qb64,))
                         break
 
-                    if ksn and ksn.ked['d'] == kever.serder.said:
+                    if ksn and ksn.d == kever.serder.said:
                         operation.done = True
                         operation.response = asdict(kever.state())
                     else:

--- a/tests/app/test_agenting.py
+++ b/tests/app/test_agenting.py
@@ -367,7 +367,7 @@ def test_querier(helpers):
         doist = doing.Doist(limit=1.0, tock=0.03125, real=True)
         deeds = doist.enter(doers=[qry])
 
-        qry.queries.append(dict(pre="EI7AkI40M11MS7lkTCb10JC9-nDt-tXwQh44OHAFlv_9", sn=1))
+        qry.queries.append(dict(pre="EI7AkI40M11MS7lkTCb10JC9-nDt-tXwQh44OHAFlv_9", sn="1"))
         qry.recur(1.0, deeds=deeds)
 
         assert len(qry.doers) == 1

--- a/tests/core/test_longrunning.py
+++ b/tests/core/test_longrunning.py
@@ -1,3 +1,5 @@
+from keri.help import helping
+
 from keria.app import aiding
 from keri.kering import ValidationError
 from keria.core import longrunning
@@ -155,6 +157,16 @@ def test_operations(helpers):
         res = client.simulate_get(path="/operations")
         assert isinstance(res.json, list)
         assert len(res.json) == 0
+
+        op = agent.monitor.status(
+            longrunning.Op(type='query', oid=recp, start=helping.nowIso8601(), metadata={'sn': '0'}))
+        assert op.name == f"query.{recp}"
+        assert op.done is True
+
+        op = agent.monitor.status(
+            longrunning.Op(type='query', oid=recp, start=helping.nowIso8601(), metadata={'sn': '4'}))
+        assert op.name == f"query.{recp}"
+        assert op.done is False
 
 
 def test_error(helpers):


### PR DESCRIPTION
This PR fixes queries to use hex string for sequence number