### PR TITLE
Fix name validation

### DIFF
--- a/src/keria/app/aiding.py
+++ b/src/keria/app/aiding.py
@@ -442,6 +442,9 @@ class IdentifierResourceEnd:
             name (str): human readable name for Hab to GET
 
         """
+        if not name:
+            raise falcon.HTTPBadRequest(description="name is required")
+
         agent = req.context.agent
         hab = agent.hby.habByName(name)
         if hab is None:
@@ -630,6 +633,9 @@ class IdentifierOOBICollectionEnd:
 
         """
         agent = req.context.agent
+        if not name:
+            raise falcon.HTTPBadRequest(description="name is required")
+
         hab = agent.hby.habByName(name)
         if not hab:
             raise falcon.HTTPNotFound(description="invalid alias {name}")

--- a/src/keria/end/ending.py
+++ b/src/keria/end/ending.py
@@ -48,7 +48,7 @@ class OOBIEnd:
             eid: qb64 identifier prefix of participant in role
 
         """
-        if aid is None:
+        if not aid:
             if self.default is None:
                 raise falcon.HTTPNotFound(description="no blind oobi for this node")
 

--- a/tests/app/test_aiding.py
+++ b/tests/app/test_aiding.py
@@ -315,6 +315,10 @@ def test_identifier_collection_end(helpers):
         res = client.simulate_post(path="/identifiers", body=json.dumps(body))
         assert res.status_code == 202
 
+        res = client.simulate_get(path="/identifiers/")
+        assert res.status_code == 400
+        assert res.json == {'description': 'name is required', 'title': '400 Bad Request'}
+
         res = client.simulate_get(path="/identifiers")
         assert res.status_code == 200
         assert len(res.json) == 2
@@ -1227,6 +1231,11 @@ def test_oobi_ends(helpers):
         op = helpers.createAid(client, "pal", salt)
         iserder = serdering.SerderKERI(sad=op["response"])
         assert iserder.pre == "EHgwVwQT15OJvilVvW57HE4w0-GPs_Stj2OFoAHZSysY"
+
+        # Test empty
+        res = client.simulate_get("/identifiers//oobis?role=agent")
+        assert res.status_code == 400
+        assert res.json == {'description': 'name is required', 'title': '400 Bad Request'}
 
         # Test before endroles are added
         res = client.simulate_get("/identifiers/pal/oobis?role=agent")

--- a/tests/end/test_ending.py
+++ b/tests/end/test_ending.py
@@ -61,6 +61,10 @@ def test_oobi_end(helpers):
         assert res.status_code == 404
         assert res.json == {'description': 'no blind oobi for this node', 'title': '404 Not Found'}
 
+        res = client.simulate_get(path=f"/oobi/")
+        assert res.status_code == 404
+        assert res.json == {'description': 'no blind oobi for this node', 'title': '404 Not Found'}
+
         # Use a bad AID
         res = client.simulate_get(path=f"/oobi/EHXXXXXT15OJvilVvW57HE4w0-GPs_Stj2OFoAHZSys")
         assert res.status_code == 404


### PR DESCRIPTION
This PR adds validation to endpoints that require an alias to not allow for a blank string.

Closes #126 and closes #176