### PR TITLE
Check agency db on cold start

### DIFF
--- a/src/keria/app/agenting.py
+++ b/src/keria/app/agenting.py
@@ -818,7 +818,7 @@ class BootEnd:
 
         caid = icp.pre
 
-        if caid in self.agency.agents:
+        if self.agency.get(caid=caid) is not None:
             raise falcon.HTTPBadRequest(title="agent already exists",
                                         description=f"agent for controller {caid} already exists")
 


### PR DESCRIPTION
On a restart of the KERIA service the agency has an empty list of agents and thus always tries to create an agent, which causes a 500. This manually checks the agency DB if the self.agency.agents is empty which fixes the problem.