### PR TITLE
Prevent creating 2 registries per agent with the same name.

### DIFF
--- a/src/keria/app/credentialing.py
+++ b/src/keria/app/credentialing.py
@@ -162,6 +162,9 @@ class RegistryCollectionEnd:
         if hab is None:
             raise falcon.HTTPNotFound(description="alias is not a valid reference to an identifier")
 
+        if agent.rgy.registryByName(name=rname) is not None:
+            raise falcon.HTTPBadRequest(description=f"registry name {rname} already in use")
+
         registry = agent.rgy.makeSignifyRegistry(name=rname, prefix=hab.pre, regser=vcp)
 
         if hab.kever.estOnly:

--- a/tests/app/test_credentialing.py
+++ b/tests/app/test_credentialing.py
@@ -143,11 +143,15 @@ def test_registry_end(helpers, seeder):
 
         assert regser.pre in agent.tvy.tevers
 
+        result = client.simulate_post(path="/identifiers/test/registries", body=json.dumps(body).encode("utf-8"))
+        assert result.status == falcon.HTTP_400
+        assert result.json == {'description': 'registry name test already in use', 'title': '400 Bad Request'}
 
         body = dict(name="test", alias="test", vcp=regser.ked, ixn=serder.ked, sigs=sigers)
         result = client.simulate_post(path="/identifiers/bad_test/registries", body=json.dumps(body).encode("utf-8"))
         assert result.status == falcon.HTTP_404
-        assert result.json == {'description': 'alias is not a valid reference to an identifier', 'title': '404 Not Found'}
+        assert result.json == {'description': 'alias is not a valid reference to an identifier',
+                               'title': '404 Not Found'}
 
 
         result = client.simulate_get(path="/identifiers/not_test/registries")


### PR DESCRIPTION
This PR adds an error if a name is reused per agent for creating registries.  Closes #190 