### PR TITLE
Writing logs into file is configurable from cli argument

### DIFF
--- a/src/keria/app/cli/commands/start.py
+++ b/src/keria/app/cli/commands/start.py
@@ -62,11 +62,15 @@ parser.add_argument("--cafilepath", action="store", required=False, default=None
                     help="TLS server CA certificate chain")
 parser.add_argument("--loglevel", action="store", required=False, default="CRITICAL",
                     help="Set log level to DEBUG | INFO | WARNING | ERROR | CRITICAL. Default is CRITICAL")
+parser.add_argument("--logfile", action="store", required=False, default=None,
+                    help="path of the log file. If not defined, logs will not be written to the file.")
 
 
 def launch(args):
     help.ogler.level = logging.getLevelName(args.loglevel)
-    help.ogler.reopen(name=args.name, temp=True, clear=True)
+    if(args.logfile != None):
+        help.ogler.headDirPath = args.logfile
+        help.ogler.reopen(name=args.name, temp=False, clear=True)
 
     logger = help.ogler.getLogger()
 


### PR DESCRIPTION
This solves a similar issue in keripy (https://github.com/WebOfTrust/keripy/pull/737) 