### PR TITLE
fix: multisig join operation never resolves

### DIFF
--- a/src/keria/app/grouping.py
+++ b/src/keria/app/grouping.py
@@ -141,7 +141,7 @@ class MultisigJoinCollectionEnd:
 
         serder = serdering.SerderKERI(sad=rot)
         agent.groups.append(dict(pre=hab.pre, serder=serder, sigers=sigers, smids=smids, rmids=rmids))
-        op = agent.monitor.submit(serder.pre, longrunning.OpTypes.group, metadata=dict(sn=0))
+        op = agent.monitor.submit(serder.pre, longrunning.OpTypes.group, metadata=dict(sn=serder.sn))
 
         rep.content_type = "application/json"
         rep.status = falcon.HTTP_202

--- a/tests/app/test_grouping.py
+++ b/tests/app/test_grouping.py
@@ -294,7 +294,7 @@ def test_join(helpers, monkeypatch):
         assert res.status_code == 202
         assert res.json == {'done': False,
                             'error': None,
-                            'metadata': {'sn': 0},
+                            'metadata': {'sn': 3},
                             'name': 'group.EDWg3-rB5FTpcckaYdBcexGmbLIO6AvAwjaJTBlXUn_I',
                             'response': None}
 


### PR DESCRIPTION
Attempt to fix issue reported here: https://github.com/WebOfTrust/signify-ts/issues/227

With this change, the commented out steps here: https://github.com/WebOfTrust/signify-ts/pull/255/files#diff-6a2529a7963a536ba8e1b3c7f9c22eddeba360f49bdbc140a039df692ffc168aR366-R367 resolves.
