### PR TITLE
Fix references to TraitCodex after move

### DIFF
--- a/.github/workflows/python-app-ci.yml
+++ b/.github/workflows/python-app-ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ macos-latest, ubuntu-latest ]
+        os: [ macos-13, ubuntu-latest ]
 
     steps:
       - uses: actions/checkout@v3

--- a/src/keria/testing/testing_helper.py
+++ b/src/keria/testing/testing_helper.py
@@ -477,7 +477,7 @@ class Helpers:
                                   baks=[],
                                   toad="0",
                                   nonce=nonce,
-                                  cnfg=[eventing.TraitCodex.NoBackers],
+                                  cnfg=[kering.TraitCodex.NoBackers],
                                   code=coring.MtrDex.Blake3_256)
         anchor = dict(i=regser.ked['i'], s=regser.ked["s"], d=regser.said)
         serder, sigers = Helpers.interact(pre=pre, bran=salt, pidx=0, ridx=0, dig=aid['d'], sn='1', data=[anchor])

--- a/tests/app/test_credentialing.py
+++ b/tests/app/test_credentialing.py
@@ -12,7 +12,8 @@ from falcon import testing
 from hio.base import doing
 from keri.app import habbing
 from keri.core import scheming, coring, parsing, serdering
-from keri.core.eventing import TraitCodex, SealEvent
+from keri.core.eventing import SealEvent
+from keri.kering import TraitCodex
 from keri.vc import proving
 from keri.vdr import eventing
 from keri.vdr.credentialing import Regery, Registrar

--- a/tests/app/test_ipexing.py
+++ b/tests/app/test_ipexing.py
@@ -15,7 +15,7 @@ from keri import core
 from keri.app import habbing, signing
 from keri.core import eventing, coring, serdering
 from keri.help import helping
-from keri.kering import Roles
+from keri.kering import Roles, TraitCodex
 from keri.peer import exchanging
 from keri.vc import proving
 from keri.vdr import eventing as veventing
@@ -606,7 +606,7 @@ def test_multisig_grant_admit(seeder, helpers):
                                   baks=[],
                                   toad="0",
                                   nonce=nonce,
-                                  cnfg=[eventing.TraitCodex.NoBackers],
+                                  cnfg=[TraitCodex.NoBackers],
                                   code=coring.MtrDex.Blake3_256)
 
         anchor = dict(i=regser.ked['i'], s=regser.ked["s"], d=regser.said)


### PR DESCRIPTION
TraitCodex was moved in https://github.com/WebOfTrust/keripy/commit/a1c4d26895acb6117b96e36ae14aaedfc233c4f6

Pinned the macos version as in #234.

