### PR TITLE
Refactor deprecated randomNonce() with Salter().qb64

### DIFF
--- a/src/keria/app/agenting.py
+++ b/src/keria/app/agenting.py
@@ -27,7 +27,8 @@ from keri.app import configing, keeping, habbing, storing, signaling, oobiing, a
 from keri.app.grouping import Counselor
 from keri.app.keeping import Algos
 from keri.core import coring, parsing, eventing, routing, serdering
-from keri.core.coring import Ilks, randomNonce
+from keri.core.coring import Ilks
+from keri.core.signing import Salter
 from keri.db import dbing
 from keri.db.basing import OobiRecord
 from keri.vc import protocoling
@@ -1049,7 +1050,7 @@ class OOBICollectionEnd:
         else:
             raise falcon.HTTPBadRequest(description="invalid OOBI request body, either 'rpy' or 'url' is required")
 
-        oid = randomNonce()
+        oid = Salter().qb64
         op = agent.monitor.submit(oid, longrunning.OpTypes.oobi, metadata=dict(oobi=oobi))
 
         rep.status = falcon.HTTP_202

--- a/src/keria/testing/testing_helper.py
+++ b/src/keria/testing/testing_helper.py
@@ -17,6 +17,7 @@ from keri.app import keeping, habbing, configing, signing
 from keri.core import coring, eventing, parsing, routing, scheming, serdering
 from keri.core.coring import MtrDex
 from keri.core.eventing import SealEvent
+from keri.core.signing import Salter
 from keri.help import helping
 from keri.kering import TraitCodex
 from keri.vc import proving
@@ -473,7 +474,7 @@ class Helpers:
         pre = aid['i']
         assert pre == "EHgwVwQT15OJvilVvW57HE4w0-GPs_Stj2OFoAHZSysY"
 
-        nonce = coring.randomNonce()
+        nonce = Salter().qb64
         regser = veventing.incept(pre,
                                   baks=[],
                                   toad="0",

--- a/tests/app/test_credentialing.py
+++ b/tests/app/test_credentialing.py
@@ -13,6 +13,7 @@ from hio.base import doing
 from keri.app import habbing
 from keri.core import scheming, coring, parsing, serdering
 from keri.core.eventing import SealEvent
+from keri.core.signing import Salter
 from keri.kering import TraitCodex
 from keri.vc import proving
 from keri.vdr import eventing
@@ -116,7 +117,7 @@ def test_registry_end(helpers, seeder):
         result = client.simulate_post(path="/identifiers/test123/registries", body=b'{"name": "test"}')
         assert result.status == falcon.HTTP_400  # Bad Request, invalid aid name
 
-        nonce = coring.randomNonce()
+        nonce = Salter().qb64
         regser = eventing.incept(pre,
                                  baks=[],
                                  toad="0",

--- a/tests/app/test_indirecting.py
+++ b/tests/app/test_indirecting.py
@@ -10,7 +10,8 @@ from hio.help import Hict
 from keri import core
 from keri.app import habbing, httping
 from keri.core import coring, serdering
-from keri.core.coring import randomNonce, MtrDex
+from keri.core.coring import MtrDex
+from keri.core.signing import Salter
 from keri.vdr import eventing
 from keria.end import ending
 
@@ -105,7 +106,7 @@ def test_indirecting(helpers):
         regser = eventing.incept(hab.pre,
                                  baks=[],
                                  toad="0",
-                                 nonce=randomNonce(),
+                                 nonce=Salter().qb64,
                                  cnfg=[],
                                  code=MtrDex.Blake3_256)
         headers = Hict([

--- a/tests/app/test_ipexing.py
+++ b/tests/app/test_ipexing.py
@@ -14,6 +14,7 @@ from hio.help import decking
 from keri import core
 from keri.app import habbing, signing
 from keri.core import eventing, coring, serdering
+from keri.core.signing import Salter
 from keri.help import helping
 from keri.kering import Roles, TraitCodex
 from keri.peer import exchanging
@@ -601,7 +602,7 @@ def test_multisig_grant_admit(seeder, helpers):
             assert holderHab.pre in agent1.hby.kevers
 
         # Create credential registry
-        nonce = coring.randomNonce()
+        nonce = Salter().qb64
         regser = veventing.incept(issuerPre,
                                   baks=[],
                                   toad="0",

--- a/tests/app/test_notifying.py
+++ b/tests/app/test_notifying.py
@@ -7,7 +7,7 @@ Testing the Mark II Agent notification endpoint
 """
 from builtins import isinstance
 
-from keri.core.coring import randomNonce
+from keri.core.signing import Salter
 
 from keria.app import notifying, grouping
 
@@ -63,7 +63,7 @@ def test_notifications(helpers):
         assert notes[1]['a'] == dict(a=2)
 
         # Load with a non-existance last
-        last = randomNonce()
+        last = Salter().qb64
         # Not found for deleting or marking as read a non-existent note
         res = client.simulate_delete(path=f"/notifications/{last}")
         assert res.status_code == 404


### PR DESCRIPTION
Issue keripy [#739](https://github.com/WebOfTrust/keripy/issues/739)