### PR TITLE
build: pin exact keripy version in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ setup(
     python_requires='>=3.12.2',
     install_requires=[
         'hio>=0.6.12',
-        'keri>=1.2.0-dev0',
+        'keri==1.2.0-dev0',
         'mnemonic>=0.20',
         'multicommand>=1.0.0',
         'falcon>=3.1.3',

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ setup(
     python_requires='>=3.12.2',
     install_requires=[
         'hio>=0.6.12',
-        'keri==1.2.0-dev0',
+        'keri==1.2.0-dev2',
         'mnemonic>=0.20',
         'multicommand>=1.0.0',
         'falcon>=3.1.3',


### PR DESCRIPTION
To close #163 - `>=` is pulling `1.2.0-dev2` for me in a fresh build which is breaking. In absence of a lockfile, `==` brings better determinism in our builds.