### PR TITLE
The PR attempts to catch up with KERIpy delegation logic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: build-keria
 build-keria:
-	@docker buildx build --platform=linux/amd64 --no-cache -f images/keria.dockerfile --tag weboftrust/keria:0.2.0-dev0 .
+	@docker buildx build --platform=linux/amd64 --no-cache -f images/keria.dockerfile --tag weboftrust/keria:0.2.0-dev1 .
 
 publish-keria:
 	@docker push weboftrust/keria --all-tags

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ setup(
     python_requires='>=3.12.2',
     install_requires=[
         'hio>=0.6.12',
-        'keri==1.2.0-dev2',
+        'keri==1.2.0-dev3',
         'mnemonic>=0.20',
         'multicommand>=1.0.0',
         'falcon>=3.1.3',

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ setup(
     python_requires='>=3.12.2',
     install_requires=[
         'hio>=0.6.12',
-        'keri==1.2.0-dev3',
+        'keri==1.2.0-dev4',
         'mnemonic>=0.20',
         'multicommand>=1.0.0',
         'falcon>=3.1.3',

--- a/src/keria/app/agenting.py
+++ b/src/keria/app/agenting.py
@@ -9,7 +9,6 @@ import os
 from dataclasses import asdict
 from urllib.parse import urlparse, urljoin
 
-
 import falcon
 from falcon import media
 from hio.base import doing
@@ -21,7 +20,6 @@ from keri import core
 from keri.app.notifying import Notifier
 from keri.app.storing import Mailboxer
 
-
 from keri.app import configing, keeping, habbing, storing, signaling, oobiing, agenting, \
     forwarding, querying, connecting, grouping
 from keri.app.grouping import Counselor
@@ -29,7 +27,6 @@ from keri.app.keeping import Algos
 from keri.core import coring, parsing, eventing, routing, serdering
 from keri.core.coring import Ilks
 from keri.core.signing import Salter
-from keri.db import dbing
 from keri.db.basing import OobiRecord
 from keri.vc import protocoling
 
@@ -211,8 +208,8 @@ class Agency(doing.DoDoer):
                       configDir=self.configDir,
                       configFile=self.configFile)
 
-        res = self.adb.agnt.pin(keys=(caid,),
-                                val=coring.Prefixer(qb64=agent.pre))
+        self.adb.agnt.pin(keys=(caid,),
+                          val=coring.Prefixer(qb64=agent.pre))
 
         self.adb.ctrl.pin(keys=(agent.pre,),
                           val=coring.Prefixer(qb64=caid))
@@ -362,7 +359,8 @@ class Agent(doing.DoDoer):
                                      tvy=self.tvy,
                                      exc=self.exc,
                                      rvy=self.rvy,
-                                     vry=self.verifier)
+                                     vry=self.verifier,
+                                     local=True)  # disable misfit escrow until we can add another parser for remote.
 
         doers.extend([
             Initer(agentHab=agentHab, caid=caid),
@@ -373,7 +371,7 @@ class Agent(doing.DoDoer):
             Witnesser(receiptor=receiptor, witners=self.witners),
             Delegator(agentHab=agentHab, swain=self.swain, anchors=self.anchors),
             ExchangeSender(hby=hby, agentHab=agentHab, exc=self.exc, exchanges=self.exchanges),
-            Granter(hby=hby, rgy=rgy,  agentHab=agentHab, exc=self.exc, grants=self.grants),
+            Granter(hby=hby, rgy=rgy, agentHab=agentHab, exc=self.exc, grants=self.grants),
             Admitter(hby=hby, witq=self.witq, psr=self.parser, agentHab=agentHab, exc=self.exc, admits=self.admits),
             GroupRequester(hby=hby, agentHab=agentHab, counselor=self.counselor, groups=self.groups),
             SeekerDoer(seeker=self.seeker, cues=self.verifier.cues),

--- a/src/keria/app/agenting.py
+++ b/src/keria/app/agenting.py
@@ -750,6 +750,7 @@ class Escrower(doing.Doer):
     def recur(self, tyme):
         """ Process all escrows once per loop. """
         self.kvy.processEscrows()
+        self.kvy.processEscrowDelegables()
         self.rgy.processEscrows()
         self.rvy.processEscrowReply()
         if self.tvy is not None:

--- a/tests/app/test_delegating.py
+++ b/tests/app/test_delegating.py
@@ -32,10 +32,6 @@ def test_sealer():
         with pytest.raises(kering.ValidationError):
             anchorer.delegation(pre="EHgwVwQT15OJvilVvW57HE4w0-GPs_Stj2OFoAHZSysY")
 
-        # Needs a proxy
-        with pytest.raises(kering.ValidationError):
-            anchorer.delegation(pre=delegate.pre)
-
         # Run delegation to escrow inception event
         anchorer.delegation(pre=delegate.pre, proxy=proxy)
         doist.recur(deeds=deeds)


### PR DESCRIPTION
This PR includes:

* fix to delegation logic to submit to witnesses first, then ask for delegation approval
* Update to newest development release of KERIpy and added call to new Kevery.processEscrowDelegables() during escrow processing.

This PR closes #245 