### PR TITLE
Increase Escrower tock to avoid overly busy CPU during escrow processing

### DIFF
--- a/src/keria/app/agenting.py
+++ b/src/keria/app/agenting.py
@@ -5,7 +5,6 @@ keria.app.agenting module
 
 """
 import json
-import datetime
 import os
 from dataclasses import asdict
 from urllib.parse import urlparse, urljoin
@@ -750,20 +749,19 @@ class Escrower(doing.Doer):
 
         super(Escrower, self).__init__(tock=self.tock)
 
-    def recur(self, tyme=None):
+    def recur(self, tyme):
         """ Process all escrows once per loop. """
-        while True:
-            self.kvy.processEscrows()
-            self.kvy.processEscrowDelegables()
-            self.rgy.processEscrows()
-            self.rvy.processEscrowReply()
-            if self.tvy is not None:
-                self.tvy.processEscrows()
-            self.exc.processEscrow()
-            self.vry.processEscrows()
-            self.registrar.processEscrows()
-            self.credentialer.processEscrows()
-            yield self.tock
+        self.kvy.processEscrows()
+        self.kvy.processEscrowDelegables()
+        self.rgy.processEscrows()
+        self.rvy.processEscrowReply()
+        if self.tvy is not None:
+            self.tvy.processEscrows()
+        self.exc.processEscrow()
+        self.vry.processEscrows()
+        self.registrar.processEscrows()
+        self.credentialer.processEscrows()
+        return False
 
 
 def loadEnds(app):

--- a/src/keria/app/agenting.py
+++ b/src/keria/app/agenting.py
@@ -5,6 +5,7 @@ keria.app.agenting module
 
 """
 import json
+import datetime
 import os
 from dataclasses import asdict
 from urllib.parse import urlparse, urljoin
@@ -745,23 +746,24 @@ class Escrower(doing.Doer):
         self.vry = vry
         self.registrar = registrar
         self.credentialer = credentialer
+        self.tock = 1.0
 
-        super(Escrower, self).__init__()
+        super(Escrower, self).__init__(tock=self.tock)
 
-    def recur(self, tyme):
+    def recur(self, tyme=None):
         """ Process all escrows once per loop. """
-        self.kvy.processEscrows()
-        self.kvy.processEscrowDelegables()
-        self.rgy.processEscrows()
-        self.rvy.processEscrowReply()
-        if self.tvy is not None:
-            self.tvy.processEscrows()
-        self.exc.processEscrow()
-        self.vry.processEscrows()
-        self.registrar.processEscrows()
-        self.credentialer.processEscrows()
-
-        return False
+        while True:
+            self.kvy.processEscrows()
+            self.kvy.processEscrowDelegables()
+            self.rgy.processEscrows()
+            self.rvy.processEscrowReply()
+            if self.tvy is not None:
+                self.tvy.processEscrows()
+            self.exc.processEscrow()
+            self.vry.processEscrows()
+            self.registrar.processEscrows()
+            self.credentialer.processEscrows()
+            yield self.tock
 
 
 def loadEnds(app):

--- a/tests/app/test_delegating.py
+++ b/tests/app/test_delegating.py
@@ -151,7 +151,7 @@ def test_delegator_end(helpers):
             assert res.status_code == 200
             op = res.json
             count += 1
-            if count > 10:
+            if count > 60:
                 raise Exception("Delegator never processed the delegatee dip event")
         
         # Delegator escrows completed and now aknowledges the delegatee dip event


### PR DESCRIPTION
Setting tock to 1.0 second runs escrower loop 30s delay and delegator approval received after 30 seconds