### PR TITLE
feat: migrate command for all agents

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ setup(
     python_requires='>=3.12.2',
     install_requires=[
         'hio>=0.6.12',
-        'keri>=1.2.0.dev8',
+        'keri==1.2.0.dev8',
         'mnemonic>=0.20',
         'multicommand>=1.0.0',
         'falcon>=3.1.3',

--- a/src/keria/app/cli/commands/migrate.py
+++ b/src/keria/app/cli/commands/migrate.py
@@ -1,0 +1,56 @@
+# -*- encoding: utf-8 -*-
+"""
+KERIA
+keria.cli.keria.commands module
+
+"""
+import argparse
+
+from hio.base import doing
+from keri.app.cli.commands.migrate import run
+from keria.db import basing
+
+
+def handler(args):
+    """
+    Migrate KERIA agents
+
+    Args:
+        args(Namespace): arguments object from command line
+    """
+    migrator = MigrateDoDoer(args)
+    return [migrator]
+
+
+parser = argparse.ArgumentParser(description='Runs outstanding migrations for all agents')
+parser.set_defaults(handler=handler,
+                    transferable=True)
+parser.add_argument('--base', '-b', help='additional optional prefix to file location of KERI keystore',
+                    required=False, default="")
+
+
+class MigrateDoDoer(doing.DoDoer):
+    def __init__(self, args):
+        self.args = args
+        self.adb = basing.AgencyBaser(name="TheAgency", base=args.base, reopen=True, temp=False)
+        doers = [doing.doify(self.migrateAgentsDo)]
+
+        super(MigrateDoDoer, self).__init__(doers=doers)
+
+    def migrateAgentsDo(self, tymth, tock=0.0):
+        """ For each agent in the agency, add a migrate doer
+
+        Parameters:
+            tymth (function): injected function wrapper closure returned by .tymen() of
+                Tymist instance. Calling tymth() returns associated Tymist .tyme.
+            tock (float): injected initial tock value
+
+        """
+        self.wind(tymth)
+        self.tock = tock
+        _ = (yield self.tock)
+
+        for ((caid,), _) in self.adb.agnt.getItemIter():
+            args = run.parser.parse_args(['--name', caid, '--base', self.args.base, '--temp', False])
+            self.extend([run.MigrateDoer(args)])
+        return True


### PR DESCRIPTION
This PR adds a `keria migrate` command that will fetch all of the agents from the agency DB and kick off the migrate doer used in `kli migrate`. Slightly weird to mimic a kli command from keria but it works, and means we will pick up changes to `kli migrate`.

I also pinned the keripy version again - this got unpinned by mistake it seems. But as mentioned before we need it for determinism of builds.

Here is a screenshot example of incepting 2-of-2 multi-sig on an old version, trying to connect without migrating and successfully migrating:
![image](https://github.com/user-attachments/assets/01d4954a-3627-4ec9-a32f-1423b27b77d5)

**Note:** `SignifyGroupHabs` are not correctly migrated on keripy - but this is separate for now and has been raised in #257 - I gave some details on why in that issue yesterday.