### PR TITLE
feat: endpoint to process credential from (acdc, iss) without IPEX

### DIFF
--- a/src/keria/app/credentialing.py
+++ b/src/keria/app/credentialing.py
@@ -43,8 +43,8 @@ def loadEnds(app, identifierResource):
     queryCollectionEnd = CredentialQueryCollectionEnd()
     app.add_route("/credentials/query", queryCollectionEnd)
 
-    credentialProcessEnd = CredentialProcessCollectionEnd()
-    app.add_route("/credentials/process", credentialProcessEnd)
+    credentialVerificationEnd = CredentialVerificationCollectionEnd()
+    app.add_route("/credentials/verify", credentialVerificationEnd)
 
 
 class RegistryCollectionEnd:
@@ -410,18 +410,18 @@ class SchemaCollectionEnd:
         rep.data = json.dumps(data).encode("utf-8")
 
 
-class CredentialProcessCollectionEnd:
+class CredentialVerificationCollectionEnd:
     @staticmethod
     def on_post(req, rep):
-        """ Process credential endpoint
+        """ Verify credential endpoint (no IPEX)
 
         Parameters:
             req: falcon.Request HTTP request
             rep: falcon.Response HTTP response
 
         ---
-        summary: Process or parse a credential
-        description: Process or parse a credential without using IPEX
+        summary: Verify a credential without IPEX
+        description: Verify a credential without using IPEX (TEL should be updated separately)
         tags:
            - Credentials
         requestBody:

--- a/src/keria/app/credentialing.py
+++ b/src/keria/app/credentialing.py
@@ -43,6 +43,9 @@ def loadEnds(app, identifierResource):
     queryCollectionEnd = CredentialQueryCollectionEnd()
     app.add_route("/credentials/query", queryCollectionEnd)
 
+    credentialProcessEnd = CredentialProcessCollectionEnd()
+    app.add_route("/credentials/process", credentialProcessEnd)
+
 
 class RegistryCollectionEnd:
     """
@@ -405,6 +408,69 @@ class SchemaCollectionEnd:
 
         rep.status = falcon.HTTP_200
         rep.data = json.dumps(data).encode("utf-8")
+
+
+class CredentialProcessCollectionEnd:
+    @staticmethod
+    def on_post(req, rep):
+        """ Process credential endpoint
+
+        Parameters:
+            req: falcon.Request HTTP request
+            rep: falcon.Response HTTP response
+
+        ---
+        summary: Process or parse a credential
+        description: Process or parse a credential without using IPEX
+        tags:
+           - Credentials
+        requestBody:
+            required: true
+            content:
+              application/json:
+                schema:
+                  type: object
+                  required:
+                    - acdc
+                    - iss
+                  properties:
+                    acdc:
+                      type: object
+                      description: KED of ACDC
+                    iss:
+                      type: object
+                      description: KED of issuing event in VC TEL
+        responses:
+           202:
+              description: Credential accepted for parsing
+              content:
+                  application/json:
+                    schema:
+                        description: long running operation of credential processing
+                        type: object
+           404:
+              description: Malformed ACDC or iss event
+        """
+        agent = req.context.agent
+        body = req.get_media()
+
+        try:
+            creder = serdering.SerderACDC(sad=httping.getRequiredParam(body, "acdc"))
+            iserder = serdering.SerderKERI(sad=httping.getRequiredParam(body, "iss"))
+        except (kering.ValidationError, json.decoder.JSONDecodeError) as e:
+            rep.status = falcon.HTTP_400
+            rep.text = e.args[0]
+            return
+
+        prefixer = coring.Prefixer(qb64=iserder.pre)
+        seqner = coring.Seqner(sn=iserder.sn)
+        saider = coring.Saider(qb64=iserder.said)
+
+        agent.parser.ims.extend(signing.serialize(creder, prefixer, seqner, saider))
+        op = agent.monitor.submit(creder.said, longrunning.OpTypes.credential,
+                                  metadata=dict(ced=creder.sad))
+        rep.status = falcon.HTTP_202
+        rep.data = op.to_json().encode("utf-8")
 
 
 class CredentialQueryCollectionEnd:

--- a/tests/app/test_credentialing.py
+++ b/tests/app/test_credentialing.py
@@ -321,15 +321,15 @@ def test_issue_credential(helpers, seeder):
         agent1.parser.parse(ims=agent.rgy.reger.cloneTvtAt(creder.said))
         assert agent1.rgy.tevers[registry["regk"]].vcSn(creder.said) is not None
 
-        credProcessEnd = credentialing.CredentialProcessCollectionEnd()
-        app1.add_route("/credentials/process", credProcessEnd)
+        credVerifyEnd = credentialing.CredentialVerificationCollectionEnd()
+        app1.add_route("/credentials/verify", credVerifyEnd)
 
         body = dict(acdc=creder.sad, iss=regser.ked)  # still has changed LEI
-        result = client1.simulate_post(path="/credentials/process", body=json.dumps(body).encode("utf-8"))
+        result = client1.simulate_post(path="/credentials/verify", body=json.dumps(body).encode("utf-8"))
         assert result.status_code == 400
 
         body["acdc"]["a"]["LEI"] = "254900DA0GOGCFVWB618"  # change back
-        result = client1.simulate_post(path="/credentials/process", body=json.dumps(body).encode("utf-8"))
+        result = client1.simulate_post(path="/credentials/verify", body=json.dumps(body).encode("utf-8"))
         assert result.status_code == 202
 
         deeds = doist.enter(doers=[agent1])


### PR DESCRIPTION
Endpoint to accept ACDC and issuing event from TEL and process it. The issuing event is only used to craft the `SealSourceTriple` used when processing and saving the credential.

I'd like in the future if this could be a bytestream but right now the signed headers interface doesn't allow it. In fact, we don't need the entire iss event to create the `SealSourceTriple` but I think it's OK for now.

This processing is effectively what the parser already does when the discloser in IPEX streams the events to the disclosee but supports use cases that have ACDCs available at 

The operation will only complete if the TEL events (and anchoring KEL events) are known to the agent. More work needed to trigger TEL queries via KERIA. WebOfTrust/keripy#868 leads to supporting that properly but I can also submit a smaller PR there to just use `tels` without `tsn` to get something fully working.