### PR TITLE
Release idle agents

### DIFF
--- a/src/keria/app/agenting.py
+++ b/src/keria/app/agenting.py
@@ -804,7 +804,7 @@ class Escrower(doing.Doer):
     
 class Releaser(doing.Doer):
     KERIAReleaserTimeOut = "KERIA_RELEASER_TIMEOUT"
-    TimeoutRel = int(os.getenv(KERIAReleaserTimeOut or 1*60*60))
+    TimeoutRel = int(os.getenv(KERIAReleaserTimeOut, "86400"))
     def __init__(self, agency):
         """ Check open agents and close if idle for more than TimeoutRel seconds
         Parameters:

--- a/src/keria/app/agenting.py
+++ b/src/keria/app/agenting.py
@@ -232,7 +232,7 @@ class Agency(doing.DoDoer):
 
         del self.agents[agent.caid]
 
-    def close(self, agent):
+    def shut(self, agent):
         logger.info(f"closing idle agent {agent.caid}")
         self.remove(agent.doers)
         self.remove([agent])
@@ -828,7 +828,7 @@ class Releaser(doing.Doer):
                     idle.append(caid)
 
             for caid in idle:
-                self.agency.close(self.agents[caid])
+                self.agency.shut(self.agents[caid])
             yield self.tock
 
 def loadEnds(app):

--- a/src/keria/app/agenting.py
+++ b/src/keria/app/agenting.py
@@ -233,6 +233,10 @@ class Agency(doing.DoDoer):
         del self.agents[agent.caid]
 
     def close(self, agent):
+        logger.info(f"closing idle agent {agent.caid}")
+        self.remove(agent.doers)
+        self.remove([agent])
+        del self.agents[agent.caid]
         agent.hby.ks.close(clear=False)
         agent.seeker.close(clear=False)
         agent.exnseeker.close(clear=False)
@@ -242,9 +246,7 @@ class Agency(doing.DoDoer):
         agent.registrar.rgy.close()
         agent.mgr.rb.close(clear=False)
         agent.hby.close(clear=False)
-        self.remove(agent.doers)
-        self.remove([agent])
-        del self.agents[agent.caid]
+
 
     def get(self, caid):
         if caid in self.agents:

--- a/src/keria/app/agenting.py
+++ b/src/keria/app/agenting.py
@@ -804,7 +804,7 @@ class Escrower(doing.Doer):
     
 class Releaser(doing.Doer):
     KERIAReleaserTimeOut = "KERIA_RELEASER_TIMEOUT"
-    TimeoutRel = int(os.getenv(KERIAReleaserTimeOut)) or 1*60*60
+    TimeoutRel = int(os.getenv(KERIAReleaserTimeOut or 1*60*60))
     def __init__(self, agency):
         """ Check open agents and close if idle for more than TimeoutRel seconds
         Parameters:

--- a/src/keria/app/agenting.py
+++ b/src/keria/app/agenting.py
@@ -6,6 +6,7 @@ keria.app.agenting module
 """
 import json
 import os
+import datetime
 from dataclasses import asdict
 from urllib.parse import urlparse, urljoin
 from types import MappingProxyType
@@ -175,7 +176,7 @@ class Agency(doing.DoDoer):
         self.agents = dict()
 
         self.adb = adb if adb is not None else basing.AgencyBaser(name="TheAgency", base=base, reopen=True, temp=temp)
-        super(Agency, self).__init__(doers=[], always=True)
+        super(Agency, self).__init__(doers=[Releaser(self)], always=True)
 
     def create(self, caid, salt=None):
         ks = keeping.Keeper(name=caid,
@@ -231,9 +232,25 @@ class Agency(doing.DoDoer):
 
         del self.agents[agent.caid]
 
+    def close(self, agent):
+        agent.hby.ks.close(clear=False)
+        agent.seeker.close(clear=False)
+        agent.exnseeker.close(clear=False)
+        agent.monitor.opr.close(clear=False)
+        agent.notifier.noter.close(clear=False)
+        agent.rep.mbx.close(clear=False)
+        agent.registrar.rgy.close()
+        agent.mgr.rb.close(clear=False)
+        agent.hby.close(clear=False)
+        self.remove(agent.doers)
+        self.remove([agent])
+        del self.agents[agent.caid]
+
     def get(self, caid):
         if caid in self.agents:
-            return self.agents[caid]
+            agent = self.agents[caid]
+            agent.last = helping.nowUTC()
+            return agent
 
         aaid = self.adb.agnt.get(keys=(caid,))
         if aaid is None:
@@ -292,6 +309,8 @@ class Agent(doing.DoDoer):
         self.caid = caid
         self.cfd = MappingProxyType(dict(self.hby.cf.get()) if self.hby.cf is not None else dict())
         self.tocks = MappingProxyType(self.cfd.get("tocks", {}))
+
+        self.last = helping.nowUTC()
 
         self.swain = delegating.Anchorer(hby=hby, proxy=agentHab)
         self.counselor = Counselor(hby=hby, swain=self.swain, proxy=agentHab)
@@ -782,7 +801,33 @@ class Escrower(doing.Doer):
         self.registrar.processEscrows()
         self.credentialer.processEscrows()
         return False
+    
+class Releaser(doing.Doer):
+    KERIAReleaserTimeOut = "KERIA_RELEASER_TIMEOUT"
+    TimeoutRel = int(os.getenv(KERIAReleaserTimeOut)) or 1*60*60
+    def __init__(self, agency):
+        """ Check open agents and close if idle for more than TimeoutRel seconds
+        Parameters:
+            agency (Agency): KERIA agent manager
+ 
+        """
+        self.tock = 60.0
+        self.agents = agency.agents
+        self.agency = agency
 
+        super(Releaser, self).__init__(tock=self.tock)
+
+    def recur(self, tyme=None):
+        while True:
+            idle = []
+            for caid in self.agents:
+                now = helping.nowUTC()
+                if (now - self.agents[caid].last) > datetime.timedelta(seconds=self.TimeoutRel):
+                    idle.append(caid)
+
+            for caid in idle:
+                self.agency.close(self.agents[caid])
+            yield self.tock
 
 def loadEnds(app):
     opColEnd = longrunning.OperationCollectionEnd()

--- a/src/keria/app/agenting.py
+++ b/src/keria/app/agenting.py
@@ -234,7 +234,7 @@ class Agency(doing.DoDoer):
 
     def shut(self, agent):
         logger.info(f"closing idle agent {agent.caid}")
-        self.remove(agent.doers)
+        agent.remove(agent.doers)
         self.remove([agent])
         del self.agents[agent.caid]
         agent.hby.ks.close(clear=False)
@@ -246,7 +246,6 @@ class Agency(doing.DoDoer):
         agent.registrar.rgy.close()
         agent.mgr.rb.close(clear=False)
         agent.hby.close(clear=False)
-
 
     def get(self, caid):
         if caid in self.agents:

--- a/tests/app/test_agenting.py
+++ b/tests/app/test_agenting.py
@@ -193,6 +193,9 @@ def test_agency():
         if os.path.exists(f'/usr/local/var/keri/adb/{base}'):
             shutil.rmtree(f'/usr/local/var/keri/adb/{base}')
 
+        agency.shut(agent)
+        assert caid not in agency.agents
+        assert len(agent.doers) == 0
 
 def test_boot_ends(helpers):
     agency = agenting.Agency(name="agency", bran=None, temp=True)


### PR DESCRIPTION
This PR generates a process that runs every 60 seconds and check if an agent was idle for more than `x` hours. In that case, the agent is shut down, releasing locked lmdb files and terminating its doers. `x` can be configured in the env variable `KERIA_RELEASER_TIMEOUT`.

What's the problem we are trying to solve:
When a client boots an agent or connects again to the agent, KERIA instantiates the Agent that opens several databases. That agent lives forever or until KERIA is restarted. Also, when the agent initiates, it locks many LMDB databases that locks the db file but also allocate a considerable amount of virtual memory. We detected that when the amount of users grows, it may impact performance of the OS slowing down KERIA responses.