### PR TITLE
feat: return 409 if agent already booted

### DIFF
--- a/src/keria/app/agenting.py
+++ b/src/keria/app/agenting.py
@@ -890,8 +890,8 @@ class BootEnd:
         caid = icp.pre
 
         if self.agency.get(caid=caid) is not None:
-            raise falcon.HTTPBadRequest(title="agent already exists",
-                                        description=f"agent for controller {caid} already exists")
+            raise falcon.HTTPConflict(title="agent already exists",
+                                      description=f"agent for controller {caid} already exists")
 
         agent = self.agency.create(caid=caid)
 

--- a/tests/app/test_agenting.py
+++ b/tests/app/test_agenting.py
@@ -224,7 +224,7 @@ def test_boot_ends(helpers):
     assert rep.status_code == 202
 
     rep = client.simulate_post("/boot", body=json.dumps(body).encode("utf-8"))
-    assert rep.status_code == 400
+    assert rep.status_code == 409
     assert rep.json == {
         'title': 'agent already exists',
         'description': 'agent for controller EK35JRNdfVkO4JwhXaSTdV4qzB_ibk_tGJmSVcY4pZqx already exists'


### PR DESCRIPTION
I think 409 is more appropriate here, and gives it some separation from the various other 400 responses from this endpoint without relying on text responses which are more subject to change.