### PR TITLE
build: docker multi-arch builds for x86 and arm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,25 @@
 .PHONY: build-keria
-build-keria:
-	@docker buildx build --platform=linux/amd64 --no-cache -f images/keria.dockerfile --tag weboftrust/keria:0.2.0-dev3 .
+
+VERSION=0.2.0-dev3
+
+define DOCKER_WARNING
+In order to use the multi-platform build enable the containerd image store
+The containerd image store is not enabled by default.
+To enable the feature for Docker Desktop:
+	Navigate to Settings in Docker Desktop.
+	In the General tab, check Use containerd for pulling and storing images.
+	Select Apply and Restart."
+endef
+
+build-keria: .warn
+	@docker build --platform=linux/amd64,linux/arm64 --no-cache -f images/keria.dockerfile -t weboftrust/keria:$(VERSION) .
 
 publish-keria:
-	@docker push weboftrust/keria --all-tags
+	@docker push weboftrust/keria:$(VERSION)
+
+.warn:
+	@echo -e ${RED}"$$DOCKER_WARNING"${NO_COLOUR}
+
+RED="\033[0;31m"
+NO_COLOUR="\033[0m"
+export DOCKER_WARNING

--- a/README.md
+++ b/README.md
@@ -84,3 +84,18 @@ You can see a [working example here](https://github.com/WebOfTrust/signify-ts/bl
     ```bash
       pytest tests/
     ```
+
+## Publishing containers
+
+Enable the containerd image store
+
+The containerd image store isn't enabled by default. To enable the feature for Docker Desktop:
+
+Navigate to Settings in Docker Desktop.
+In the General tab, check Use containerd for pulling and storing images.
+Select Apply & Restart.
+
+```shell
+make build-keri
+make publish-keri
+```


### PR DESCRIPTION
This is a direct copy of @m00sey's keripy work in WebOfTrust/keripy#832 but for KERIA, hopefully no issues.

Adds arm docker builds and makes them available on the same tag for both architectures. (and resolves the re-publishing of old builds from `--all-tags` push)