### PR TITLE
fix: docker image reference cannot contain uppercase characters

### DIFF
--- a/.github/workflows/publish-keria.yml
+++ b/.github/workflows/publish-keria.yml
@@ -1,4 +1,3 @@
-
 name: Publish Docker image
 
 on:
@@ -24,7 +23,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: WebOfTrust/keria
+          images: weboftrust/keria
 
       - name: Set up Docker buildx
         id: buildx
@@ -45,8 +44,8 @@ jobs:
           file: images/keria.dockerfile
           push: true
           tags: |
-            WebOfTrust/keria:${{ github.event.inputs.version }}
-            WebOfTrust/keria:latest
+            weboftrust/keria:${{ github.event.inputs.version }}
+            weboftrust/keria:latest
           labels: ${{ github.event.inputs.version }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max


### PR DESCRIPTION
Using `WebOfTrust/keria` as the image name causes docker to choke and try to publish to a docker registry hosted at `WebOfTrust` instead of `docker.io`. This is what happened here: https://github.com/WebOfTrust/keria/actions/runs/11315384968/job/31466498211

Closes #309 

Read more here: https://docs.docker.com/reference/cli/docker/image/tag/

> PATH: The path consists of slash-separated components. Each component may contain **lowercase letters**, digits and separators. A separator is defined as a period, one or two underscores, or one or more hyphens. A component may not start or end with a separator. While the [OCI Distribution Specification](https://github.com/opencontainers/distribution-spec) supports more than two slash-separated components, most registries only support two slash-separated components. For Docker's public registry, the path format is as follows: