### PR TITLE
fix: allow cors with falcon 4

### DIFF
--- a/src/keria/core/httping.py
+++ b/src/keria/core/httping.py
@@ -15,7 +15,7 @@ class HandleCORS(object):
         resp.set_header('Access-Control-Allow-Headers', '*')
         resp.set_header('Access-Control-Max-Age', 1728000)  # 20 days
         if req.method == 'OPTIONS':
-            raise HTTPStatus(falcon.HTTP_200, body='\n')
+            raise HTTPStatus(falcon.HTTP_200)
 
 
 def getRequiredParam(body, name):


### PR DESCRIPTION
Falcon 4 has been released so setup.py is picking this up, and it has this slight interface change.