### PR TITLE
build: bump to 0.2.0-dev5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: build-keria
 
-VERSION=0.2.0-dev4
+VERSION=0.2.0-dev5
 
 define DOCKER_WARNING
 In order to use the multi-platform build enable the containerd image store

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ from setuptools import setup
 
 setup(
     name='keria',
-    version='0.2.0-dev4',  # also change in src/keria/__init__.py
+    version='0.2.0-dev5',  # also change in src/keria/__init__.py
     license='Apache Software License 2.0',
     description='KERIA: KERI Agent in the cloud',
     long_description="KERIA: KERI Agent in the cloud.",

--- a/src/keria/__init__.py
+++ b/src/keria/__init__.py
@@ -3,5 +3,5 @@
 main package
 """
 
-__version__ = '0.2.0-dev4'  # also change in setup.py
+__version__ = '0.2.0-dev5'  # also change in setup.py
 


### PR DESCRIPTION
To support https://github.com/WebOfTrust/signify-ts/pull/290