### PR TITLE
feat: delete/remove credential endpoint

### DIFF
--- a/src/keria/app/credentialing.py
+++ b/src/keria/app/credentialing.py
@@ -789,6 +789,55 @@ class CredentialResourceEnd:
 
         return out
 
+    @staticmethod
+    def on_delete(req, rep, said):
+        """ Credentials DELETE endpoint
+
+        Parameters:
+            req: falcon.Request HTTP request
+            rep: falcon.Response HTTP response
+            said (str): SAID of credential to delete
+
+        ---
+        summary: Delete a credential from the database
+        description: Delete a credential from the database and remove any associated indices
+        tags:
+           - Credentials
+        parameters:
+           - in: path
+             name: said
+             schema:
+               type: string
+             required: true
+             description: SAID of credential to delete
+        responses:
+           204:
+              description: Credential deleted successfully
+           400:
+             description: The requested credential was not found
+        """
+        reger = req.context.agent.rgy.reger
+
+        try:
+            creder, _, _, _ = reger.cloneCred(said)
+        except kering.MissingEntryError:
+            raise falcon.HTTPNotFound(description=f"credential for said {said} not found.")
+
+        saider = coring.Saider(qb64b=said)
+
+        if not isinstance(creder.attrib, str) and 'i' in creder.attrib:
+            subj = creder.attrib["i"]
+            if subj:
+                reger.subjs.rem(keys=subj, val=saider)
+
+        reger.schms.rem(keys=creder.sad["s"], val=saider)
+        reger.issus.rem(keys=creder.sad["i"], val=saider)
+        reger.saved.rem(keys=said)
+        reger.creds.rem(keys=said)
+        reger.cancs.rem(keys=said)
+
+        rep.status = falcon.HTTP_204
+
 
 class CredentialResourceDeleteEnd:
     def __init__(self, identifierResource):

--- a/tests/app/test_credentialing.py
+++ b/tests/app/test_credentialing.py
@@ -487,6 +487,22 @@ def test_credentialing_ends(helpers, seeder):
         assert res.json == {'description': f"registry EBVaw6pCqfMIiZGkA6qevzRUGsxTRuZXxl6YG1neeCGF not found",
                             'title': '404 Not Found'}
 
+        res = client.simulate_delete(f"/credentials/doesnotexist")
+        assert res.status_code == 404
+        assert res.json == {'description': f"credential for said doesnotexist not found.",
+                            'title': '404 Not Found'}
+
+        res = client.simulate_delete(f"/credentials/{saids[0]}")
+        assert res.status_code == 204
+
+        # Check db directly to make sure all indices are gone too (GET endpoints don't cover all indices)
+        assert agent.rgy.reger.creds.get(keys=saids[0]) is None
+        assert agent.rgy.reger.cancs.get(keys=saids[0]) is None
+        assert agent.rgy.reger.saved.get(keys=saids[0]) is None
+        assert agent.rgy.reger.issus.cnt(keys=hab.pre) == 4
+        assert agent.rgy.reger.schms.cnt(keys="EFgnk_c08WmZGgv9_mpldibRuqFMTQN-rAgtD-TCOwbs") == 1
+        assert agent.rgy.reger.subjs.cnt(keys=issuee) == 4
+
 
 def test_revoke_credential(helpers, seeder):
     with helpers.openKeria() as (agency, agent, app, client):


### PR DESCRIPTION
Resolves #79. `DELETE /credentials/{said}` - it will remove the credential from the DB and any associated indices.

This is different to revoke, which is under `DELETE /identifiers/{name}/credentials/{said}` (the path used for issuance).