### PR TITLE
ci(gha): multi-arch docker builds

### DIFF
--- a/.github/workflows/publish-keria.yml
+++ b/.github/workflows/publish-keria.yml
@@ -25,6 +25,10 @@ jobs:
         with:
           images: weboftrust/keria
 
+      # For multi-arch
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker buildx
         id: buildx
         uses: docker/setup-buildx-action@v3
@@ -38,10 +42,11 @@ jobs:
             keri-${{ runner.os }}-buildx-
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: images/keria.dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             weboftrust/keria:${{ github.event.inputs.version }}


### PR DESCRIPTION
To resolve #329. The Makefile is only used for local pushes, so also updating this.

Looking at the output of https://github.com/WebOfTrust/keria/actions/runs/11900767151/job/33162302638 -> `Set up Docker buildx` -> `Inspect builder` -> `"platforms": "linux/amd64,linux/amd64/v2,linux/amd64/v3,linux/386"`, we will need QEMU for arm.