### PR TITLE
feat: basic protection boot endpoint

### DIFF
--- a/src/keria/app/agenting.py
+++ b/src/keria/app/agenting.py
@@ -885,6 +885,7 @@ class BootEnd:
         self.agency = agency
 
     def authenticate(self, req: falcon.Request):
+        # Username AND Password is not set, so no need to authenticate
         if self.username is None and self.password is None:
             return
 
@@ -897,6 +898,9 @@ class BootEnd:
 
         try:
             username, password = b64decode(token).decode('utf-8').split(':')
+
+            if username is None or password is None:
+                raise falcon.HTTPUnauthorized(title="Unauthorized")
 
             if username == self.username and password == self.password:
                 return

--- a/src/keria/app/cli/commands/start.py
+++ b/src/keria/app/cli/commands/start.py
@@ -100,8 +100,8 @@ def launch(args):
                             curls=getListVariable("KERIA_CURLS"),
                             iurls=getListVariable("KERIA_IURLS"),
                             durls=getListVariable("KERIA_DURLS"),
-                            bootPassword=os.getenv("KERIA_BOOT_PASSWORD"),
-                            bootUsername=os.getenv("KERIA_BOOT_USERNAME"))
+                            bootPassword=os.getenv("KERIA_EXPERIMENTAL_BOOT_PASSWORD"),
+                            bootUsername=os.getenv("KERIA_EXPERIMENTAL_BOOT_USERNAME"))
 
     directing.runController(doers=agency, expire=0.0)
 

--- a/src/keria/app/cli/commands/start.py
+++ b/src/keria/app/cli/commands/start.py
@@ -68,6 +68,14 @@ parser.add_argument("--loglevel", action="store", required=False, default=os.get
                     help="Set log level to DEBUG | INFO | WARNING | ERROR | CRITICAL. Default is CRITICAL")
 parser.add_argument("--logfile", action="store", required=False, default=None,
                     help="path of the log file. If not defined, logs will not be written to the file.")
+parser.add_argument("--experimental-boot-password",
+                    help="Experimental password for boot endpoint. Enables HTTP Basic Authentication for the boot endpoint. Only meant to be used for testing purposes.",
+                    dest="bootPassword",
+                    default=os.getenv("KERIA_EXPERIMENTAL_BOOT_PASSWORD"))
+parser.add_argument("--experimental-boot-username",
+                    help="Experimental username for boot endpoint. Enables HTTP Basic Authentication for the boot endpoint. Only meant to be used for testing purposes.",
+                    dest="bootUsername",
+                    default=os.getenv("KERIA_EXPERIMENTAL_BOOT_USERNAME"))
 
 def getListVariable(name):
     value = os.getenv(name)
@@ -100,8 +108,8 @@ def launch(args):
                             curls=getListVariable("KERIA_CURLS"),
                             iurls=getListVariable("KERIA_IURLS"),
                             durls=getListVariable("KERIA_DURLS"),
-                            bootPassword=os.getenv("KERIA_EXPERIMENTAL_BOOT_PASSWORD"),
-                            bootUsername=os.getenv("KERIA_EXPERIMENTAL_BOOT_USERNAME"))
+                            bootPassword=args.bootPassword,
+                            bootUsername=args.bootUsername)
 
     directing.runController(doers=agency, expire=0.0)
 

--- a/src/keria/app/cli/commands/start.py
+++ b/src/keria/app/cli/commands/start.py
@@ -99,7 +99,9 @@ def launch(args):
                             releaseTimeout=int(os.getenv("KERIA_RELEASER_TIMEOUT", "86400")),
                             curls=getListVariable("KERIA_CURLS"),
                             iurls=getListVariable("KERIA_IURLS"),
-                            durls=getListVariable("KERIA_DURLS"))
+                            durls=getListVariable("KERIA_DURLS"),
+                            bootPassword=os.getenv("KERIA_BOOT_PASSWORD"),
+                            bootUsername=os.getenv("KERIA_BOOT_USERNAME"))
 
     directing.runController(doers=agency, expire=0.0)
 

--- a/tests/app/test_agenting.py
+++ b/tests/app/test_agenting.py
@@ -5,6 +5,7 @@ keria.app.agenting module
 
 Testing the Mark II Agent
 """
+from base64 import b64encode
 import json
 import os
 import shutil
@@ -248,7 +249,7 @@ def test_agency_with_urls_from_arguments():
         assert agent.hby.cf.get()["iurls"] == iurls
         assert agent.hby.cf.get()["durls"] == durls
 
-def test_boot_ends(helpers):
+def test_unprotected_boot_ends(helpers):
     agency = agenting.Agency(name="agency", bran=None, temp=True)
     doist = doing.Doist(limit=1.0, tock=0.03125, real=True)
     doist.enter(doers=[agency])
@@ -280,6 +281,51 @@ def test_boot_ends(helpers):
         'title': 'agent already exists',
         'description': 'agent for controller EK35JRNdfVkO4JwhXaSTdV4qzB_ibk_tGJmSVcY4pZqx already exists'
     }
+
+def test_protected_boot_ends(helpers):
+    agency = agenting.Agency(name="agency", bran=None, temp=True)
+    doist = doing.Doist(limit=1.0, tock=0.03125, real=True)
+    doist.enter(doers=[agency])
+
+    serder, sigers = helpers.controller()
+    assert serder.pre == helpers.controllerAID
+
+    app = falcon.App()
+    client = testing.TestClient(app)
+
+    username = "test"
+    password = "test"
+
+    bootEnd = agenting.BootEnd(agency, username=username, password=password)
+    app.add_route("/boot", bootEnd)
+
+    body = dict(
+        icp=serder.ked,
+        sig=sigers[0].qb64,
+        salty=dict(
+            stem='signify:aid', pidx=0, tier='low', sxlt='OBXYZ',
+            icodes=[MtrDex.Ed25519_Seed], ncodes=[MtrDex.Ed25519_Seed]
+        )
+    )
+
+    rep = client.simulate_post("/boot", body=json.dumps(body).encode("utf-8"))
+    assert rep.status_code == 401
+
+    rep = client.simulate_post("/boot", body=json.dumps(body).encode("utf-8"), headers={"Authorization": "Something test"})
+    assert rep.status_code == 401
+
+    rep = client.simulate_post("/boot", body=json.dumps(body).encode("utf-8"), headers={"Authorization": "Basic test:test"})
+    assert rep.status_code == 401
+
+    rep = client.simulate_post("/boot", body=json.dumps(body).encode("utf-8"), headers={"Authorization": f"Basic {b64encode(b'test:foobar').decode('utf-8')}"} )
+    assert rep.status_code == 401
+
+    rep = client.simulate_post("/boot", body=json.dumps(body).encode("utf-8"), headers={"Authorization": f"Basic {b64encode(b'foobar:test').decode('utf-8')}"} )
+    assert rep.status_code == 401
+
+    authorization = f"Basic {b64encode(b'test:test').decode('utf-8')}"
+    rep = client.simulate_post("/boot", body=json.dumps(body).encode("utf-8"), headers={"Authorization": authorization})
+    assert rep.status_code == 202
 
 
 def test_witnesser(helpers):


### PR DESCRIPTION
This PR implements a basic protection of the boot endpoint, this enables you to more easily deploy test instances publicly. This way you can add the authorization to the URL. See rationale in #327

Closes #327

If we also land #333, I will rebase this on top and also expose this feature as command line flags.

I also thought this could be implemented as a falcon middleware. But wanted to get feedback first whether or not it should be included at all.