### PR TITLE
feat: expose inception dts in hab info

### DIFF
--- a/src/keria/app/aiding.py
+++ b/src/keria/app/aiding.py
@@ -13,8 +13,7 @@ from keri import kering
 from keri import core
 from keri.app import habbing
 from keri.app.keeping import Algos
-from keri.core import coring, serdering
-from keri.core.coring import Ilks
+from keri.core import coring, serdering, eventing
 from keri.db import dbing
 from keri.help import ogler
 from mnemonic import mnemonic
@@ -999,6 +998,8 @@ def info(hab, rm, full=False):
     data.update(keeper.params(pre=hab.pre))
     if isinstance(hab, habbing.SignifyGroupHab):
         data["group"]["mhab"] = info(hab.mhab, rm, full)
+
+    data["icp_dt"] = bytes(hab.db.getDts(eventing.dgKey(hab.pre, hab.pre))).decode("utf-8")
 
     if hab.accepted and full:
         kever = hab.kevers[hab.pre]

--- a/tests/app/test_aiding.py
+++ b/tests/app/test_aiding.py
@@ -10,6 +10,7 @@ from dataclasses import asdict
 import json
 import os
 import pytest
+from datetime import datetime
 
 import falcon
 from falcon import testing
@@ -1625,7 +1626,7 @@ def test_rotation(helpers):
         assert aid["prefix"] == "EHgwVwQT15OJvilVvW57HE4w0-GPs_Stj2OFoAHZSysY"
 
         icp_dt = aid["icp_dt"]
-        assert icp_dt is not None
+        datetime.fromisoformat(icp_dt)  # will raise an error if the format is not a valid iso dt
 
         serder2, signers2 = helpers.incept(salt, "signify:aid", pidx=1, count=3)
         sigers2 = [signer.sign(ser=serder2.raw, index=0).qb64 for signer in signers2]

--- a/tests/app/test_aiding.py
+++ b/tests/app/test_aiding.py
@@ -1624,6 +1624,9 @@ def test_rotation(helpers):
         assert aid["name"] == "aid1"
         assert aid["prefix"] == "EHgwVwQT15OJvilVvW57HE4w0-GPs_Stj2OFoAHZSysY"
 
+        icp_dt = aid["icp_dt"]
+        assert icp_dt is not None
+
         serder2, signers2 = helpers.incept(salt, "signify:aid", pidx=1, count=3)
         sigers2 = [signer.sign(ser=serder2.raw, index=0).qb64 for signer in signers2]
 
@@ -1716,6 +1719,11 @@ def test_rotation(helpers):
         assert res.json['done'] is True
 
         res = client.simulate_get(path=f"/identifiers/{aid1['name']}")
+        assert res.status_code == 200
+
+        # Ensure rotation doesn't change dt
+        assert res.json["icp_dt"] == icp_dt
+
         mhab = res.json
         agent0 = mhab["state"]
 


### PR DESCRIPTION
Exposing the identifier creation time in hab info. Useful for displaying in a UI.

For so far as I can tell this value is always set even when the identifier is still in escrow.