### PR TITLE
fix: 400 for invalid end role signatures

### DIFF
--- a/src/keria/app/aiding.py
+++ b/src/keria/app/aiding.py
@@ -1330,8 +1330,8 @@ class EndRoleCollectionEnd:
         )
         try:
             agent.hby.rvy.processReply(rserder, tsgs=[tsg])
-        except kering.ValidationError:
-            raise falcon.HTTPBadRequest(description="invalid signatures for given end role reply message")
+        except (kering.UnverifiedReplyError, kering.ValidationError):
+            raise falcon.HTTPBadRequest(description="unable to verify end role reply message")
 
         oid = ".".join([pre, role, eid])
         op = agent.monitor.submit(

--- a/src/keria/app/aiding.py
+++ b/src/keria/app/aiding.py
@@ -1330,8 +1330,8 @@ class EndRoleCollectionEnd:
         )
         try:
             agent.hby.rvy.processReply(rserder, tsgs=[tsg])
-        except kering.UnverifiedReplyError:
-            pass
+        except kering.ValidationError:
+            raise falcon.HTTPBadRequest(description="invalid signatures for given end role reply message")
 
         oid = ".".join([pre, role, eid])
         op = agent.monitor.submit(

--- a/tests/app/test_aiding.py
+++ b/tests/app/test_aiding.py
@@ -1379,7 +1379,7 @@ def test_oobi_ends(helpers):
         body = dict(rpy=rpy.ked, sigs=sigs)
         res = client.simulate_post(path=f"/identifiers/pal/endroles", json=body)
         assert res.status_code == 400
-        assert res.json == {'description': "invalid signatures for given end role reply message",
+        assert res.json == {'description': "unable to verify end role reply message",
                             'title': '400 Bad Request'}
 
         # now with correct

--- a/tests/app/test_aiding.py
+++ b/tests/app/test_aiding.py
@@ -1373,6 +1373,16 @@ def test_oobi_ends(helpers):
         assert res.json == {'oobis': [], 'role': 'agent'}
 
         rpy = helpers.endrole(iserder.pre, agent.agentHab.pre)
+
+        # first try with bad signatures
+        sigs = helpers.sign(b'0123456789xyzxyz', 0, 0, rpy.raw)
+        body = dict(rpy=rpy.ked, sigs=sigs)
+        res = client.simulate_post(path=f"/identifiers/pal/endroles", json=body)
+        assert res.status_code == 400
+        assert res.json == {'description': "invalid signatures for given end role reply message",
+                            'title': '400 Bad Request'}
+
+        # now with correct
         sigs = helpers.sign(salt, 0, 0, rpy.raw)
         body = dict(rpy=rpy.ked, sigs=sigs)
 
@@ -1388,6 +1398,7 @@ def test_oobi_ends(helpers):
 
         res = client.simulate_post(path=f"/endroles/pal", json=body)
         assert res.status_code == 404
+
 
         # must be a valid aid alias
         res = client.simulate_get("/identifiers/bad/oobis")


### PR DESCRIPTION
Feedback to client instead of passing the exception.

Based on the test, passing bad signatures causes `kering.ValidationError` to be thrown from `validateSigs` before `kering.UnverifiedReplyError` is hit.