### PR TITLE
fix: pass UnverifiedReplyError again for end role

### DIFF
--- a/src/keria/app/aiding.py
+++ b/src/keria/app/aiding.py
@@ -1330,7 +1330,9 @@ class EndRoleCollectionEnd:
         )
         try:
             agent.hby.rvy.processReply(rserder, tsgs=[tsg])
-        except (kering.UnverifiedReplyError, kering.ValidationError):
+        except kering.UnverifiedReplyError:
+            pass
+        except kering.ValidationError:
             raise falcon.HTTPBadRequest(description="unable to verify end role reply message")
 
         oid = ".".join([pre, role, eid])


### PR DESCRIPTION
#344 was wrong because `UnverifiedReplyError` is thrown for insufficient signatures (e.g. multi-sig). Adjusted to only return 400 for invalid signatures.