### PR TITLE
fix: always use Agent proxy when sending messages from SignifyGroupHab

### DIFF
--- a/src/keria/app/delegating.py
+++ b/src/keria/app/delegating.py
@@ -163,10 +163,10 @@ class Anchorer(doing.DoDoer):
                 print(f"Witness receipts complete, waiting for delegation approval.")
                 if isinstance(hab, habbing.GroupHab):
                     phab = hab.mhab
-                elif hab.kever.sn > 0:
-                    phab = hab
                 elif self.proxy is not None:
                     phab = self.proxy
+                elif hab.kever.sn > 0:
+                    phab = hab
                 else:
                     raise kering.ValidationError("no proxy to send messages for delegation")
 


### PR DESCRIPTION
This fixes delegated multisig rotation with KERIA and Signify multisig groups. Prior to this fix then sending a delegated multisig rotation would always trigger a `kering.KeriError` as shown below because the existing if else chain sets `phab = hab as shown below.

First, the `def sign` in `SignifyHab` throwing the `KeriError`.
```python
class SignifyHab(BaseHab):
    ...
    def sign(self, ser, verfers=None, indexed=True, indices=None, ondices=None, **kwa):
        ...
        raise kering.KeriError("Signify hab does not support local signing")
```

Next, the if/else chain in `keria.app.delegating.Anchorer.processPartialWitnessEscrow`
```python
class Anchorer:
    ...
    def processPartialWitnessEscrow(...):
        ...
                if isinstance(hab, habbing.GroupHab):
                    phab = hab.mhab
                elif hab.kever.sn > 0:
                    phab = hab  # <-- this branch was being incorrectly called because for SignifyGroupHab instances where the delegate has undergone a rotation result in this branch evaluating to true, preventing the check for the self.proxy.
                elif self.proxy is not None:
                    phab = self.proxy
        ...
```

The new code causes this Anchorer to always check for a proxy and use it if specified:
```python
                if isinstance(hab, habbing.GroupHab):
                    phab = hab.mhab
                elif self.proxy is not None:
                    phab = self.proxy
                elif hab.kever.sn > 0:
                    phab = hab
```