### PR TITLE
fix: delete keria specific indexes when deleting a credential

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,7 @@ setup(
         'pytest>=8.3.4',
     ],
     setup_requires=[
-        'setuptools==75.8.0'
+        'setuptools==75.8.2'
     ],
     entry_points={
         'console_scripts': [

--- a/src/keria/app/credentialing.py
+++ b/src/keria/app/credentialing.py
@@ -816,15 +816,17 @@ class CredentialResourceEnd:
            400:
              description: The requested credential was not found
         """
-        reger = req.context.agent.rgy.reger
+        agent = req.context.agent
+        reger = agent.rgy.reger
 
         try:
             creder, _, _, _ = reger.cloneCred(said)
         except kering.MissingEntryError:
             raise falcon.HTTPNotFound(description=f"credential for said {said} not found.")
 
-        saider = coring.Saider(qb64b=said)
+        agent.seeker.unindex(said)
 
+        saider = coring.Saider(qb64b=said)
         if not isinstance(creder.attrib, str) and 'i' in creder.attrib:
             subj = creder.attrib["i"]
             if subj:

--- a/src/keria/db/basing.py
+++ b/src/keria/db/basing.py
@@ -214,6 +214,26 @@ class Seeker(dbing.LMDBer):
             value = "".join(values)
             db.add(keys=(value,), val=saider)
 
+    def unindex(self, said):
+        if (saider := self.reger.saved.get(keys=(said,))) is None:
+            raise ValueError(f"{said} is not a verified credential")
+
+        creder = self.reger.creds.get(keys=(saider.qb64,))
+        indexes = self.schIdx.get(keys=(creder.schema,))
+        if not indexes:
+            raise ValueError(f"No known indexes for schema {creder.schema}")
+
+        for index in indexes:
+            db = self.indexes[index]
+            idx = self.dynIdx.get(keys=(index,))
+            values = []
+            for path in idx.paths:
+                pather = coring.Pather(qb64=path)
+                values.append(pather.resolve(creder.sad))
+
+            value = "".join(values)
+            db.rem(keys=(value,), val=saider)
+
     def generateIndexes(self, said):
         """ Parse schema of said, create schIdx entry keyed to said of schema and the subkey indexes in
         self.indexes

--- a/tests/app/test_basing.py
+++ b/tests/app/test_basing.py
@@ -66,7 +66,7 @@ def test_seeker(helpers, seeder, mockHelpingNowUTC):
                            '4AAB-a-i.5AACAA-a-LEI',
                            '4AAB-a-i.5AABAA-s.5AACAA-a-LEI']
 
-        # Test that the index tables were correctly ereated
+        # Test that the index tables were correctly created
         assert len(seeker.indexes) == 29
 
         indexes = seeker.generateIndexes(LE_SAID)
@@ -102,14 +102,14 @@ def test_seeker(helpers, seeder, mockHelpingNowUTC):
                            '4AAB-a-i.5AACAA-a-LEI',
                            '4AAB-a-i.5AABAA-s.5AACAA-a-LEI']
 
-        # Assure that no knew index tables needed to be created
+        # Assure that no new index tables needed to be created
         assert len(seeker.indexes) == 29
 
         # Test with a bad credential SAID
         with pytest.raises(ValueError):
             seeker.index("EZ-i0d8JZAoTNZH3ULaU6JR2nmwyvYAfSVPzhzS6b5CM")
 
-        # test credemtial with "oneOf"
+        # test credential with "oneOf"
         seeker.generateIndexes(said="EBfdlu8R27Fbx-ehrqwImnK-8Cm79sqbAQ4MmvEAYqao")
 
         issuer.createRegistry(issuerHab.pre, name="issuer")
@@ -166,6 +166,31 @@ def test_seeker(helpers, seeder, mockHelpingNowUTC):
 
         saids = seeker.find({'-i': {'$eq': issuerHab.pre}, '-a-LEI': {'$eq': 'U6452GAE5C4TVRUY9EIX'}}).sort(['-a-LEI'])
         assert list(saids) == ['ELDA-hNidE8nsNOYAg993mOLiYAew_eIgicEiK_ilb9Y']
+
+        # Try to unindex unknown credential
+        with pytest.raises(ValueError):
+            seeker.unindex("EZ-i0d8JZAoTNZH3ULaU6JR2nmwyvYAfSVPzhzS6b5CM")
+
+        # Unindex the last one in prep for deletion from DB
+        seeker.unindex(qvisaid)
+
+        saids = seeker.find({'-a-LEI': "ZUQA6QTJDNYPF3DLP9NH"})
+        assert list(saids) == []
+
+        saids = seeker.find({'-a-LEI': {"$eq": "ZUQA6QTJDNYPF3DLP9NH"}})
+        assert list(saids) == []
+
+        saids = seeker.find({}).sort(['-a-LEI']).skip(45).limit(5)
+        assert list(saids) == ['EI9K4digb0UgEPi0ZT4Rw1DlSSx5NewLpxl4M-XurJMO',
+                               'ELAcuTv3lYs7P6N9uP6Ob2oQ10CWhTLpGWJOht5VPvPT',
+                               'EFl7rgKSxQdEsFomKbeXfSDfGG_9QE0oDzNQ9v8DsJmJ',
+                               'EOP0GO5JXnEq8BbcRHzUOeokxV45efXzyeDzJsV8_aTn']
+
+        saids = seeker.find({'-i': {'$eq': issuerHab.pre}, '-a-LEI': {'$begins': 'Z'}}).sort(['-a-LEI'])
+        assert list(saids) == ['EOP0GO5JXnEq8BbcRHzUOeokxV45efXzyeDzJsV8_aTn']
+
+        saids = seeker.find({'-i': {'$eq': issuerHab.pre}, '-a-LEI': {'$eq': 'ZUQA6QTJDNYPF3DLP9NH'}}).sort(['-a-LEI'])
+        assert list(saids) == []
 
 
 def randomLEI():

--- a/tests/app/test_credentialing.py
+++ b/tests/app/test_credentialing.py
@@ -504,6 +504,12 @@ def test_credentialing_ends(helpers, seeder):
         assert res.status_code == 200
         assert len(res.json) == 4
 
+        # Query using specific filter to check indexes
+        body = json.dumps({'filter': {'-a-LEI': "984500E5DEFDBQ1O9038"}}).encode("utf-8")
+        res = client.simulate_post(f"/credentials/query", body=body)
+        assert res.status_code == 200
+        assert len(res.json) == 0
+
         # Check db directly to make sure all indices are gone too (GET endpoints don't cover all indices)
         assert agent.rgy.reger.creds.get(keys=saids[0]) is None
         assert agent.rgy.reger.cancs.get(keys=saids[0]) is None


### PR DESCRIPTION
When I added the endpoint to delete a credential by SAID from DB (not revoke, just wipe it), I deleted the simple indexes used by keripy. What I missed was the `agenting.Seeker` will create much more sophisticated indexes based on the schema.

I missed this because `/credentials/query` without a filter doesn't search these indexes, only when you pass something more specific like searching based on issuer, attribute etc.

And if it finds it by this indexed search, it can't return it because `cloneCred` will throw an error.