### PR TITLE
adds a ruff check for unused imports

### DIFF
--- a/.github/workflows/python-app-ci.yml
+++ b/.github/workflows/python-app-ci.yml
@@ -38,7 +38,6 @@ jobs:
           flake8 . --count --exit-zero --ignore=E7,F841,E301,E302,E303 --max-complexity=10 --max-line-length=127 --statistics
       - name: Ruff checks
         run: |
-          pip install ruff
           ruff check
         
       - name: Run core KERI tests

--- a/.github/workflows/python-app-ci.yml
+++ b/.github/workflows/python-app-ci.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install flake8 pytest hio requests
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          if [ -f requirements.txt ]; then pip install -r requirements.txt keria[dev]; fi
       - name: Lint changes
         run: |
           # stop the build if there are Python syntax errors or undefined names

--- a/.github/workflows/python-app-ci.yml
+++ b/.github/workflows/python-app-ci.yml
@@ -36,6 +36,11 @@ jobs:
           flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
           # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
           flake8 . --count --exit-zero --ignore=E7,F841,E301,E302,E303 --max-complexity=10 --max-line-length=127 --statistics
+      - name: Ruff checks
+        run: |
+          pip install ruff
+          ruff check
+        
       - name: Run core KERI tests
         run: |
           pytest tests/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build-keria ruff-check
+.PHONY: build-keria
 
 VERSION=0.2.0-rc1
 IMAGE_NAME=weboftrust/keria

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build-keria
+.PHONY: build-keria ruff-check
 
 VERSION=0.2.0-rc1
 IMAGE_NAME=weboftrust/keria

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,20 @@
+output-format = "concise"
+target-version = "py312"
+line-length = 120
+
+include = ["src/**/*.py", "tests/**/*.py"]
+
+exclude = [
+    ".git",
+    ".venv",
+    "dist",
+    "docs",
+    "scripts",
+    "static"
+]
+
+[lint]
+select = ["F401"]
+ignore = []
+fixable = ["ALL"]
+unfixable = []

--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,8 @@ setup(
     ],
     extras_require={
         'test': ['pytest', 'coverage'],
-        'docs': ['sphinx', 'sphinx-rtd-theme']
+        'docs': ['sphinx', 'sphinx-rtd-theme'],
+        'dev': ['ruff>=0.8.0', 'pytest', 'coverage']
     },
     tests_require=[
         'coverage>=7.6.10',

--- a/src/keria/app/agenting.py
+++ b/src/keria/app/agenting.py
@@ -22,7 +22,7 @@ from hio.base import doing, Doer
 from hio.core import http, tcp
 from hio.help import decking
 
-from keri import core, kering, help
+from keri import core, kering
 from keri.app.notifying import Notifier
 from keri.app.storing import Mailboxer
 

--- a/src/keria/app/cli/commands/start.py
+++ b/src/keria/app/cli/commands/start.py
@@ -6,7 +6,6 @@ keria.cli.keria.commands.start module
 KERIA Agent server start command line interface (CLI) command
 """
 import argparse
-import logging
 import os
 
 

--- a/src/keria/app/indirecting.py
+++ b/src/keria/app/indirecting.py
@@ -7,7 +7,6 @@ simple indirect mode demo support classes
 """
 import falcon
 from keri.app import httping
-from keri.core import eventing
 from keri.core.coring import Ilks, Sadder
 from keri.kering import Protocols, Kinds
 

--- a/src/keria/app/ipexing.py
+++ b/src/keria/app/ipexing.py
@@ -5,12 +5,11 @@ keria.app.ipexing module
 
 services and endpoint for IPEX message managements
 """
-import json
 
 import falcon
 from keri import core
 from keri.app import habbing
-from keri.core import coring, eventing, serdering
+from keri.core import eventing, serdering
 from keri.peer import exchanging
 
 from keria.core import httping, longrunning

--- a/src/keria/app/notifying.py
+++ b/src/keria/app/notifying.py
@@ -7,7 +7,6 @@ keria.app.notifying module
 import json
 
 import falcon
-from keri.peer import exchanging
 
 from keria.core import httping
 

--- a/src/keria/app/serving.py
+++ b/src/keria/app/serving.py
@@ -1,6 +1,6 @@
 import signal
 
-from hio.base import doing, Doist
+from hio.base import doing
 from keri import help
 
 logger = help.ogler.getLogger()

--- a/tests/app/test_agenting.py
+++ b/tests/app/test_agenting.py
@@ -19,7 +19,7 @@ import pytest
 import requests
 from falcon import testing
 from hio.base import doing, tyming
-from hio.core import http, tcp
+from hio.core import http
 from hio.help import decking
 from keri import core
 from keri import kering

--- a/tests/app/test_aiding.py
+++ b/tests/app/test_aiding.py
@@ -9,7 +9,6 @@ from builtins import isinstance
 from dataclasses import asdict
 import json
 import os
-import pytest
 from datetime import datetime
 
 import falcon

--- a/tests/app/test_delegating.py
+++ b/tests/app/test_delegating.py
@@ -12,7 +12,7 @@ import pytest
 from hio.base import doing
 from keri import kering
 from keri.app import habbing
-from keri.core import coring, eventing, parsing, serdering
+from keri.core import coring, eventing, parsing
 
 from keria.app import aiding, delegating
 from keria.core import longrunning

--- a/tests/app/test_indirecting.py
+++ b/tests/app/test_indirecting.py
@@ -9,7 +9,7 @@ import falcon.testing
 from hio.help import Hict
 from keri import core
 from keri.app import habbing, httping
-from keri.core import coring, serdering
+from keri.core import serdering
 from keri.core.coring import MtrDex
 from keri.core.signing import Salter
 from keri.vdr import eventing

--- a/tests/app/test_notifying.py
+++ b/tests/app/test_notifying.py
@@ -9,7 +9,7 @@ from builtins import isinstance
 
 from keri.core.signing import Salter
 
-from keria.app import notifying, grouping
+from keria.app import notifying
 
 
 def test_load_ends(helpers):

--- a/tests/core/test_authing.py
+++ b/tests/core/test_authing.py
@@ -13,7 +13,7 @@ from hio.help import Hict
 from keri import kering
 from keri import core
 from keri.app import habbing
-from keri.core import parsing, eventing, coring
+from keri.core import parsing, eventing
 from keri.end import ending
 
 from keria.app import agenting


### PR DESCRIPTION
@lenkan pointed out some unused imports in pending/merged PRs.

This addresses it retroactively.

The introduction of Ruff allows the maintainers to expand the linting/checks of the repo as necessary.
Potentially the flake8 checks can be replaced.