### PR TITLE
chore: add ruff linting

### DIFF
--- a/.github/workflows/python-app-ci.yml
+++ b/.github/workflows/python-app-ci.yml
@@ -28,15 +28,11 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install flake8 pytest hio requests
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          pip install -r requirements.txt keria[dev]
       - name: Lint changes
         run: |
-          # stop the build if there are Python syntax errors or undefined names
-          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-          flake8 . --count --exit-zero --ignore=E7,F841,E301,E302,E303 --max-complexity=10 --max-line-length=127 --statistics
-      - name: Run core KERI tests
+          ruff check
+      - name: Run core KERIA tests
         run: |
           pytest tests/
 

--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,8 @@ setup(
     ],
     extras_require={
         'test': ['pytest', 'coverage'],
-        'docs': ['sphinx', 'sphinx-rtd-theme']
+        'docs': ['sphinx', 'sphinx-rtd-theme'],
+        'dev': ['ruff>=0.8.0', 'pytest>=8.3.4', 'coverage>=7.6.10', 'requests'],
     },
     tests_require=[
         'coverage>=7.6.10',

--- a/src/keria/app/agenting.py
+++ b/src/keria/app/agenting.py
@@ -22,7 +22,7 @@ from hio.base import doing, Doer
 from hio.core import http, tcp
 from hio.help import decking
 
-from keri import core, kering, help
+from keri import core, kering
 from keri.app.notifying import Notifier
 from keri.app.storing import Mailboxer
 
@@ -895,7 +895,7 @@ class ExchangeSender(doing.DoDoer):
             rec = msg["rec"]
             topic = msg['topic']
             hab = self.hby.habs[pre]
-            logger.debug("[%s | %s]: Current Message Body= %s", hab.name, hab.pre, msg);
+            logger.debug("[%s | %s]: Current Message Body= %s", hab.name, hab.pre, msg)
             if self.exc.lead(hab, said=said):
                 atc = exchanging.serializeMessage(self.hby, said)
                 del atc[:serder.size]
@@ -1348,12 +1348,12 @@ class BootEnd:
         body = req.get_media()
         if "icp" not in body:
             raise falcon.HTTPBadRequest(title="invalid inception",
-                                        description=f'required field "icp" missing from body')
+                                        description='required field "icp" missing from body')
         icp = serdering.SerderKERI(sad=body["icp"])
 
         if "sig" not in body:
             raise falcon.HTTPBadRequest(title="invalid inception",
-                                        description=f'required field "sig" missing from body')
+                                        description='required field "sig" missing from body')
         siger = core.Siger(qb64=body["sig"])
 
         caid = icp.pre
@@ -1394,12 +1394,12 @@ class BootEnd:
             rand = body[Algos.randy]
             if "pris" not in rand:
                 raise falcon.HTTPBadRequest(title="invalid inception",
-                                            description=f'required field "pris" missing from body.rand')
+                                            description='required field "pris" missing from body.rand')
             pris = rand["pris"]
 
             if "nxts" not in rand:
                 raise falcon.HTTPBadRequest(title="invalid inception",
-                                            description=f'required field "nxts" missing from body.rand')
+                                            description='required field "nxts" missing from body.rand')
             nxts = rand["nxts"]
 
             mgr = agent.mgr.get(algo=Algos.randy)

--- a/src/keria/app/aiding.py
+++ b/src/keria/app/aiding.py
@@ -494,7 +494,7 @@ class IdentifierCollectionEnd:
 
                 if "mhab" not in group:
                     raise falcon.HTTPBadRequest(
-                        description=f'required field "mhab" missing from body.group'
+                        description='required field "mhab" missing from body.group'
                     )
                 mpre = group["mhab"]["prefix"]
 
@@ -506,7 +506,7 @@ class IdentifierCollectionEnd:
 
                 if "keys" not in group:
                     raise falcon.HTTPBadRequest(
-                        description=f'required field "keys" missing from body.group'
+                        description='required field "keys" missing from body.group'
                     )
                 keys = group["keys"]
                 verfers = [coring.Verfer(qb64=key) for key in keys]
@@ -519,7 +519,7 @@ class IdentifierCollectionEnd:
 
                 if "ndigs" not in group:
                     raise falcon.HTTPBadRequest(
-                        description=f'required field "ndigs" missing from body.group'
+                        description='required field "ndigs" missing from body.group'
                     )
                 ndigs = group["ndigs"]
                 digers = [coring.Diger(qb64=ndig) for ndig in ndigs]
@@ -812,7 +812,7 @@ class IdentifierResourceEnd:
             else:
                 raise falcon.HTTPBadRequest(
                     title="invalid request",
-                    description=f"required field 'rot' or 'ixn' missing from request",
+                    description="required field 'rot' or 'ixn' missing from request",
                 )
 
             rep.status = falcon.HTTP_200
@@ -832,7 +832,7 @@ class IdentifierResourceEnd:
         if rot is None:
             raise falcon.HTTPBadRequest(
                 title="invalid rotation",
-                description=f"required field 'rot' missing from request",
+                description="required field 'rot' missing from request",
             )
         serder = serdering.SerderKERI(sad=rot)
         logger.info("[%s | %s]: Rotation event sn=%s SAID=%s", hab.name, hab.pre, serder.sn, serder.said)
@@ -847,7 +847,7 @@ class IdentifierResourceEnd:
         if sigs is None or len(sigs) == 0:
             raise falcon.HTTPBadRequest(
                 title="invalid rotation",
-                description=f"required field 'sigs' missing from request",
+                description="required field 'sigs' missing from request",
             )
         sigers = [core.Siger(qb64=sig) for sig in sigs]
 
@@ -929,7 +929,7 @@ class IdentifierResourceEnd:
         if ixn is None:
             raise falcon.HTTPBadRequest(
                 title="invalid interaction",
-                description=f"required field 'ixn' missing from request",
+                description="required field 'ixn' missing from request",
             )
         serder = serdering.SerderKERI(sad=ixn)
         logger.info("[%s | %s] Interaction event sn=%s SAID=%s", hab.name, hab.pre, serder.sn, serder.said)
@@ -938,7 +938,7 @@ class IdentifierResourceEnd:
         if sigs is None or len(sigs) == 0:
             raise falcon.HTTPBadRequest(
                 title="invalid interaction",
-                description=f"required field 'sigs' missing from request",
+                description="required field 'sigs' missing from request",
             )
 
         sigers = [core.Siger(qb64=sig) for sig in sigs]

--- a/src/keria/app/cli/commands/start.py
+++ b/src/keria/app/cli/commands/start.py
@@ -6,7 +6,6 @@ keria.cli.keria.commands.start module
 KERIA Agent server start command line interface (CLI) command
 """
 import argparse
-import logging
 import os
 
 

--- a/src/keria/app/credentialing.py
+++ b/src/keria/app/credentialing.py
@@ -929,7 +929,7 @@ class CredentialResourceDeleteEnd:
 
         try:
             agent.rgy.reger.cloneCreds([coring.Saider(qb64=said)], db=agent.hby.db)
-        except:
+        except Exception:
             raise falcon.HTTPNotFound(description=f"credential for said {said} not found.")
 
         if hab.kever.estOnly:
@@ -941,8 +941,8 @@ class CredentialResourceDeleteEnd:
 
         try:
             agent.registrar.revoke(regk, rserder, anc)
-        except Exception as e:
-            raise falcon.HTTPBadRequest(description=f"invalid revocation event.")
+        except Exception:
+            raise falcon.HTTPBadRequest(description="invalid revocation event.")
 
         rep.status = falcon.HTTP_200
         rep.data = op.to_json().encode("utf-8")
@@ -1152,7 +1152,7 @@ class Registrar:
 
             self.counselor.start(prefixer=prefixer, seqner=seqner, saider=saider, ghab=hab)
 
-            logger.info(f"[%s | %s]: Waiting for TEL rev event mulisig anchoring event %s", hab.name, hab.pre, seqner.sn)
+            logger.info("[%s | %s]: Waiting for TEL rev event mulisig anchoring event %s", hab.name, hab.pre, seqner.sn)
             self.rgy.reger.tmse.add(keys=(vcid, rseq.qb64, rserder.said), val=(prefixer, seqner, saider))
             return vcid, rseq.sn
 
@@ -1249,7 +1249,7 @@ class Registrar:
             for msg in self.rgy.reger.clonePreIter(pre=regk, fn=rseq.sn):
                 tevt.extend(msg)
 
-            logger.info(f"Sending TEL events to witnesses")
+            logger.info("Sending TEL events to witnesses")
             # Fire and forget the TEL event to the witnesses.  Consumers will have to query
             # to determine when the Witnesses have received the TEL events.
             self.witPub.msgs.append(dict(pre=prefixer.qb64, msg=tevt))

--- a/src/keria/app/grouping.py
+++ b/src/keria/app/grouping.py
@@ -195,7 +195,7 @@ class MultisigJoinCollectionEnd:
         
         try:
             hab.make(serder=serder, sigers=sigers)
-        except (ValueError) as e:
+        except (ValueError):
             logger.info("Already incepted group, continuing...")
 
         agent.inceptGroup(pre=gid, mpre=mhab.pre, verfers=verfers, digers=digers)

--- a/src/keria/app/indirecting.py
+++ b/src/keria/app/indirecting.py
@@ -7,7 +7,6 @@ simple indirect mode demo support classes
 """
 import falcon
 from keri.app import httping
-from keri.core import eventing
 from keri.core.coring import Ilks, Sadder
 from keri.kering import Protocols, Kinds
 

--- a/src/keria/app/ipexing.py
+++ b/src/keria/app/ipexing.py
@@ -5,12 +5,11 @@ keria.app.ipexing module
 
 services and endpoint for IPEX message managements
 """
-import json
 
 import falcon
 from keri import core
 from keri.app import habbing
-from keri.core import coring, eventing, serdering
+from keri.core import eventing, serdering
 from keri.peer import exchanging
 
 from keria.core import httping, longrunning
@@ -119,7 +118,7 @@ class IpexAdmitCollectionEnd:
 
         # Have to add the atc to the end... this will be Pathed signatures for embeds
         if not atc:
-            raise falcon.HTTPBadRequest(description=f"attachment missing for multi-sig admit, unable to process request.")
+            raise falcon.HTTPBadRequest(description="attachment missing for multi-sig admit, unable to process request.")
 
         # use that data to create th Serder and Sigers for the exn
         serder = serdering.SerderKERI(sad=ked)
@@ -243,7 +242,7 @@ class IpexGrantCollectionEnd:
             raise falcon.HTTPBadRequest(description=f"invalid route for embedded ipex grant {ked['r']}")
 
         if not atc:
-            raise falcon.HTTPBadRequest(description=f"attachment missing for multi-sig grant, unable to process request.")
+            raise falcon.HTTPBadRequest(description="attachment missing for multi-sig grant, unable to process request.")
 
         # use that data to create th Serder and Sigers for the exn
         serder = serdering.SerderKERI(sad=ked)
@@ -360,7 +359,7 @@ class IpexApplyCollectionEnd:
             raise falcon.HTTPBadRequest(description=f"invalid route for embedded ipex apply {ked['r']}")
 
         if not atc:
-            raise falcon.HTTPBadRequest(description=f"attachment missing for multi-sig apply, unable to process request.")
+            raise falcon.HTTPBadRequest(description="attachment missing for multi-sig apply, unable to process request.")
 
         # use that data to create th Serder and Sigers for the exn
         serder = serdering.SerderKERI(sad=ked)
@@ -474,7 +473,7 @@ class IpexOfferCollectionEnd:
             raise falcon.HTTPBadRequest(description=f"invalid route for embedded ipex offer {ked['r']}")
 
         if not atc:
-            raise falcon.HTTPBadRequest(description=f"attachment missing for multi-sig offer, unable to process request.")
+            raise falcon.HTTPBadRequest(description="attachment missing for multi-sig offer, unable to process request.")
 
         # use that data to create th Serder and Sigers for the exn
         serder = serdering.SerderKERI(sad=ked)
@@ -591,7 +590,7 @@ class IpexAgreeCollectionEnd:
             raise falcon.HTTPBadRequest(description=f"invalid route for embedded ipex agree {ked['r']}")
 
         if not atc:
-            raise falcon.HTTPBadRequest(description=f"attachment missing for multi-sig agree, unable to process request.")
+            raise falcon.HTTPBadRequest(description="attachment missing for multi-sig agree, unable to process request.")
 
         # use that data to create th Serder and Sigers for the exn
         serder = serdering.SerderKERI(sad=ked)

--- a/src/keria/app/notifying.py
+++ b/src/keria/app/notifying.py
@@ -7,7 +7,6 @@ keria.app.notifying module
 import json
 
 import falcon
-from keri.peer import exchanging
 
 from keria.core import httping
 

--- a/src/keria/app/serving.py
+++ b/src/keria/app/serving.py
@@ -1,6 +1,6 @@
 import signal
 
-from hio.base import doing, Doist
+from hio.base import doing
 from keri import help
 
 logger = help.ogler.getLogger()
@@ -28,12 +28,12 @@ class GracefulShutdownDoer(doing.Doer):
 
     def handle_sigterm(self, signum, frame):
         """Handler function for SIGTERM"""
-        logger.info(f"Received SIGTERM, initiating graceful shutdown.")
+        logger.info("Received SIGTERM, initiating graceful shutdown.")
         self.shutdown_received = True
 
     def handle_sigint(self, signum, frame):
         """Handler function for SIGINT"""
-        logger.info(f"Received SIGINT, initiating graceful shutdown.")
+        logger.info("Received SIGINT, initiating graceful shutdown.")
         self.shutdown_received = True
 
     def shutdownAgency(self):

--- a/src/keria/core/longrunning.py
+++ b/src/keria/core/longrunning.py
@@ -149,7 +149,7 @@ class Monitor:
     def getOperations(self, type=None):
         """ Return list of long running opterations, optionally filtered by type """
         ops = self.opr.ops.getItemIter()
-        if type != None:
+        if type is not None:
             ops = filter(lambda i: i[1].type == type, ops)
 
         def get_status(op):

--- a/tests/app/test_agenting.py
+++ b/tests/app/test_agenting.py
@@ -19,7 +19,7 @@ import pytest
 import requests
 from falcon import testing
 from hio.base import doing, tyming
-from hio.core import http, tcp
+from hio.core import http
 from hio.help import decking
 from keri import core
 from keri import kering
@@ -101,7 +101,7 @@ def test_graceful_shutdown_doer():
     salter = core.Salter(raw=salt)
     cf = configing.Configer(name="keria", headDirPath=SCRIPTS_DIR, temp=True, reopen=True, clear=False)
     with habbing.openHby(name="keria", salt=salter.qb64, temp=True, cf=cf) as hby:
-        hab = hby.makeHab(name="test")
+        hby.makeHab(name="test")
 
         agency = agenting.Agency(name="agency", base="", bran=None, temp=True, configFile="keria",
                                  releaseTimeout=0, configDir=SCRIPTS_DIR)
@@ -837,7 +837,7 @@ def test_submitter(seeder, helpers):
         hab = agent.hby.habByName(alias)
         sn = 0
         msg = hab.makeOwnEvent(sn=sn)
-        rctMsgs = helpers.witnessMsg(hab=hab, msg=msg, sn=sn, witHabs=[wesHab])
+        helpers.witnessMsg(hab=hab, msg=msg, sn=sn, witHabs=[wesHab])
         wigs = hab.db.getWigs(dgkey)
         assert len(wigs) == 1 # only witnessed by one witness
         assert len(wesHab.kvy.db.getWigs(dgkey)) == 1  # only witnessed by one witness
@@ -855,7 +855,7 @@ def test_submitter(seeder, helpers):
         tock = 0.03125
         wdoist = doing.Doist(limit=limit, tock=tock, doers=wanDoers)
         wdoist.enter()
-        tymer = tyming.Tymer(tymth=wdoist.tymen(), duration=wdoist.limit)
+        tyming.Tymer(tymth=wdoist.tymen(), duration=wdoist.limit)
         aidEnd = aiding.IdentifierResourceEnd()
         app.add_route("/identifiers/{name}/submit", aidEnd)
         resSubmit = client.simulate_post(

--- a/tests/app/test_aiding.py
+++ b/tests/app/test_aiding.py
@@ -9,7 +9,6 @@ from builtins import isinstance
 from dataclasses import asdict
 import json
 import os
-import pytest
 from datetime import datetime
 
 import falcon
@@ -91,7 +90,7 @@ def test_endrole_ends(helpers):
         sigs = helpers.sign(salt, 0, 0, rpy.raw)
         body = dict(rpy=rpy.ked, sigs=sigs)
 
-        res = client.simulate_post(path=f"/identifiers/user1/endroles", json=body)
+        res = client.simulate_post(path="/identifiers/user1/endroles", json=body)
         op = res.json
         ked = op["response"]
         serder = serdering.SerderKERI(sad=ked)
@@ -104,11 +103,11 @@ def test_endrole_ends(helpers):
 
         # Test GET method
         # Must be valid aid alias
-        res = client.simulate_get(path=f"/identifiers/bad/endroles")
+        res = client.simulate_get(path="/identifiers/bad/endroles")
         assert res.status_code == 404
 
         # Get endrols
-        res = client.simulate_get(path=f"/identifiers/user1/endroles")
+        res = client.simulate_get(path="/identifiers/user1/endroles")
         assert res.status_code == 200
 
         ends = res.json
@@ -157,19 +156,19 @@ def test_locscheme_ends(helpers, mockHelpingNowUTC):
         sigs = ["AACOFnUk-lsVq0rLNdWCBtr51fnkXRdEzo8gnUwYF0F6xJPGL9_MXxezBc_P6e15-M1GpaHua_l3Hn4qKRMomRoM"]
         body = dict(rpy=rpy.ked, sigs=sigs)
 
-        res = client.simulate_post(path=f"/identifiers/unknown-user/locschemes", json=body)
+        res = client.simulate_post(path="/identifiers/unknown-user/locschemes", json=body)
         assert res.status_code == 404
         assert res.json == {'description': 'invalid alias or prefix unknown-user',
                             'title': '404 Not Found'}
 
-        res = client.simulate_post(path=f"/identifiers/user1/locschemes", json=body)
+        res = client.simulate_post(path="/identifiers/user1/locschemes", json=body)
         assert res.status_code == 400
         assert res.json == {'description': 'unable to verify end role reply message',
                             'title': '400 Bad Request'}
 
         sigs = helpers.sign(salt, 0, 0, rpy.raw)
         body = dict(rpy=rpy.ked, sigs=sigs)
-        res = client.simulate_post(path=f"/identifiers/user1/locschemes", json=body)
+        res = client.simulate_post(path="/identifiers/user1/locschemes", json=body)
         assert res.status_code == 202
         op = res.json
         assert op["done"]
@@ -187,7 +186,7 @@ def test_locscheme_ends(helpers, mockHelpingNowUTC):
         rpy = helpers.locscheme(recp, "https://testurl.com", "https")
         sigs = helpers.sign(salt, 0, 0, rpy.raw)
         body = dict(rpy=rpy.ked, sigs=sigs)
-        res = client.simulate_post(path=f"/identifiers/user1/locschemes", json=body)
+        res = client.simulate_post(path="/identifiers/user1/locschemes", json=body)
         assert res.status_code == 202
         op = res.json
         assert op["done"]
@@ -268,7 +267,7 @@ def test_agent_resource(helpers, mockHelpingNowUTC):
         # Test rotation
         body = {
         }
-        res = client.simulate_put(path=f"/agent/bad_pre", body=json.dumps(body))
+        res = client.simulate_put(path="/agent/bad_pre", body=json.dumps(body))
         assert res.status_code == 404
         assert res.json == {'description': "no agent for bad_pre",
                             'title': '404 Not Found'}
@@ -508,7 +507,7 @@ def test_identifier_collection_end(helpers):
         assert res.status_code == 200
         assert res.json['done'] is True
 
-        res = client.simulate_get(path=f"/identifiers/aid1")
+        res = client.simulate_get(path="/identifiers/aid1")
         mhab = res.json
         agent0 = mhab["state"]
         
@@ -586,7 +585,7 @@ def test_identifier_collection_end(helpers):
         # Send in all signatures as if we are joining the inception event
         sigers = [signer0.sign(ser=serder.raw, index=0).qb64, p1.sign(ser=serder.raw, indices=[1])[0].qb64,
                   p2.sign(ser=serder.raw, indices=[2])[0].qb64]
-        states = nstates = [agent0, asdict(p1.kever.state()), asdict(p2.kever.state())]
+        states = [agent0, asdict(p1.kever.state()), asdict(p2.kever.state())]
         smids = rmids = [state['i'] for state in states if 'i' in state]
 
         body = {
@@ -1091,7 +1090,7 @@ def test_challenge_ends(helpers):
 
         data["said"] = exn.said
         b = json.dumps(data).encode("utf-8")
-        result = client.simulate_put(path=f"/challenges-verify/EFt8G8gkCJ71e4amQaRUYss0BDK4pUpzKelEIr3yZ1D0",
+        result = client.simulate_put(path="/challenges-verify/EFt8G8gkCJ71e4amQaRUYss0BDK4pUpzKelEIr3yZ1D0",
                                      body=b)
         assert result.status == falcon.HTTP_404  # Missing said
 
@@ -1107,7 +1106,7 @@ def test_challenge_ends(helpers):
         assert result.status_code == 404
 
         b = json.dumps(data).encode("utf-8")
-        result = client.simulate_post(path=f"/challenges-verify/EFt8G8gkCJ71e4amQaRUYss0BDK4pUpzKelEIr3yZ1D0",
+        result = client.simulate_post(path="/challenges-verify/EFt8G8gkCJ71e4amQaRUYss0BDK4pUpzKelEIr3yZ1D0",
                                       body=b)
         assert result.status_code == 404
 
@@ -1171,11 +1170,11 @@ def test_contact_ends(helpers):
         )
         b = json.dumps(data).encode("utf-8")
         # POST to an identifier that is not in the Kever
-        response = client.simulate_post(f"/contacts/E8AKUcbZyik8EdkOwXgnyAxO5mSIPJWGZ_o7zMhnNnjo/pal", body=b)
+        response = client.simulate_post("/contacts/E8AKUcbZyik8EdkOwXgnyAxO5mSIPJWGZ_o7zMhnNnjo/pal", body=b)
         assert response.status == falcon.HTTP_404
 
         # Bad prefix
-        response = client.simulate_post(f"/contacts/bad_prefix", body=b)
+        response = client.simulate_post("/contacts/bad_prefix", body=b)
         assert response.status == falcon.HTTP_404
 
         # POST to a local identifier
@@ -1204,7 +1203,7 @@ def test_contact_ends(helpers):
         response = client.simulate_post(f"/contacts/{aids[i]}", body=b)
         assert response.status == falcon.HTTP_400
 
-        response = client.simulate_get(f"/contacts/E8AKUcbZyik8EdkOwXgnyAxO5mSIPJWGZ_o7zMhnNnjo")
+        response = client.simulate_get("/contacts/E8AKUcbZyik8EdkOwXgnyAxO5mSIPJWGZ_o7zMhnNnjo")
         assert response.status == falcon.HTTP_404
 
         response = client.simulate_get(f"/contacts/{hab.pre}")
@@ -1217,7 +1216,7 @@ def test_contact_ends(helpers):
                                  'id': 'EAjKmvW6flpWJfdYYZ2Lu4pllPWKFjCBz0dcX-S86Nvg',
                                  'last': 'Burns3'}
 
-        response = client.simulate_get(f"/contacts")
+        response = client.simulate_get("/contacts")
         assert response.status == falcon.HTTP_200
         assert len(response.json) == 5
         data = {d["id"]: d for d in response.json}
@@ -1227,7 +1226,7 @@ def test_contact_ends(helpers):
         data = dict(id=hab.pre, company="ProSapien")
         b = json.dumps(data).encode("utf-8")
 
-        response = client.simulate_put(f"/contacts/E8AKUcbZyik8EdkOwXgnyAxO5mSIPJWGZ_o7zMhnNnjo", body=b)
+        response = client.simulate_put("/contacts/E8AKUcbZyik8EdkOwXgnyAxO5mSIPJWGZ_o7zMhnNnjo", body=b)
         assert response.status == falcon.HTTP_404
 
         response = client.simulate_put(f"/contacts/{palPre}", body=b)
@@ -1324,7 +1323,7 @@ def test_contact_ends(helpers):
                                   'last': 'Burns0',
                                   'wellKnowns': []}]
 
-        response = client.simulate_delete(f"/contacts/E8AKUcbZyik8EdkOwXgnyAxO5mSIPJWGZ_o7zMhnNnjo")
+        response = client.simulate_delete("/contacts/E8AKUcbZyik8EdkOwXgnyAxO5mSIPJWGZ_o7zMhnNnjo")
         assert response.status == falcon.HTTP_404
 
         response = client.simulate_delete(f"/contacts/{aids[3]}")
@@ -1336,7 +1335,7 @@ def test_contact_ends(helpers):
 
         data = bytearray(os.urandom(50))
         headers = {"Content-Type": "image/png", "Content-Length": "50"}
-        response = client.simulate_post(f"/contacts/E8AKUcbZyik8EdkOwXgnyAxO5mSIPJWGZ_o7zMhnNnjo/img", body=data,
+        response = client.simulate_post("/contacts/E8AKUcbZyik8EdkOwXgnyAxO5mSIPJWGZ_o7zMhnNnjo/img", body=data,
                                         headers=headers)
         assert response.status == falcon.HTTP_404
 
@@ -1350,7 +1349,7 @@ def test_contact_ends(helpers):
         response = client.simulate_post(f"/contacts/{aids[0]}/img", body=data, headers=headers)
         assert response.status == falcon.HTTP_202
 
-        response = client.simulate_get(f"/contacts/E8AKUcbZyik8EdkOwXgnyAxO5mSIPJWGZ_o7zMhnNnjo/img")
+        response = client.simulate_get("/contacts/E8AKUcbZyik8EdkOwXgnyAxO5mSIPJWGZ_o7zMhnNnjo/img")
         assert response.status == falcon.HTTP_404
 
         response = client.simulate_get(f"/contacts/{aids[2]}/img")
@@ -1366,8 +1365,8 @@ def test_contact_ends(helpers):
 
 def test_identifier_resource_end(helpers):
     with helpers.openKeria() as (agency, agent, app, client), \
-            habbing.openHby(name="p1", temp=True) as p1hby, \
-            habbing.openHby(name="p2", temp=True) as p2hby:
+            habbing.openHby(name="p1", temp=True), \
+            habbing.openHby(name="p2", temp=True):
         end = aiding.IdentifierCollectionEnd()
         resend = aiding.IdentifierResourceEnd()
         app.add_route("/identifiers", end)
@@ -1437,7 +1436,7 @@ def test_oobi_ends(helpers):
         # first try with bad signatures
         sigs = helpers.sign(b'0123456789xyzxyz', 0, 0, rpy.raw)
         body = dict(rpy=rpy.ked, sigs=sigs)
-        res = client.simulate_post(path=f"/identifiers/pal/endroles", json=body)
+        res = client.simulate_post(path="/identifiers/pal/endroles", json=body)
         assert res.status_code == 400
         assert res.json == {'description': "unable to verify end role reply message",
                             'title': '400 Bad Request'}
@@ -1446,17 +1445,17 @@ def test_oobi_ends(helpers):
         sigs = helpers.sign(salt, 0, 0, rpy.raw)
         body = dict(rpy=rpy.ked, sigs=sigs)
 
-        res = client.simulate_post(path=f"/identifiers/pal/endroles", json=body)
+        res = client.simulate_post(path="/identifiers/pal/endroles", json=body)
         op = res.json
         ked = op["response"]
         serder = serdering.SerderKERI(sad=ked)
         assert serder.raw == rpy.raw
 
         # not valid calls
-        res = client.simulate_post(path=f"/identifiers/pal/endroles/agent", json=body)
+        res = client.simulate_post(path="/identifiers/pal/endroles/agent", json=body)
         assert res.status_code == 404
 
-        res = client.simulate_post(path=f"/endroles/pal", json=body)
+        res = client.simulate_post(path="/endroles/pal", json=body)
         assert res.status_code == 404
 
 
@@ -1516,7 +1515,7 @@ def test_oobi_ends(helpers):
         sigs = helpers.sign(salt, 0, 0, rpy.raw)
         body = dict(rpy=rpy.ked, sigs=sigs)
 
-        res = client.simulate_post(path=f"/identifiers/pal/endroles", json=body)
+        res = client.simulate_post(path="/identifiers/pal/endroles", json=body)
         op = res.json
         ked = op["response"]
         serder = serdering.SerderKERI(sad=ked)
@@ -1572,7 +1571,7 @@ def test_approve_delegation(helpers):
     cf = configing.Configer(name="keria", headDirPath=SCRIPTS_DIR, temp=True, reopen=True, clear=False)
 
     with habbing.openHby(name="keria", salt=salter.qb64, temp=True, cf=cf) as hby:
-        hab = hby.makeHab(name="test")
+        hby.makeHab(name="test")
         agency = agenting.Agency(name="agency", bran=None, temp=True)
         agentHab = hby.makeHab(caid, ns="agent", transferable=True, data=[caid])
 
@@ -1650,8 +1649,8 @@ def test_rotation(helpers):
     salter = core.Salter(raw=salt)
 
     with helpers.openKeria() as (agency, agent, app, client), \
-            habbing.openHby(name="p1", temp=True, salt=salter.qb64) as p1hby, \
-            habbing.openHby(name="p2", temp=True, salt=salter.qb64) as p2hby:
+            habbing.openHby(name="p1", temp=True, salt=salter.qb64), \
+            habbing.openHby(name="p2", temp=True, salt=salter.qb64):
         end = aiding.IdentifierCollectionEnd()
         resend = aiding.IdentifierResourceEnd()
         app.add_route("/identifiers", end)
@@ -1797,7 +1796,7 @@ def test_rotation(helpers):
         assert res.json["icp_dt"] == icp_dt
 
         mhab = res.json
-        agent0 = mhab["state"]
+        mhab["state"]
 
         # rotate aid3
         body = helpers.createRotate(aid=aid3, salt=salt, signers=signers3, pidx=3, ridx=1, kidx=3, wits=wits3, toad=toad3)

--- a/tests/app/test_credentialing.py
+++ b/tests/app/test_credentialing.py
@@ -204,20 +204,20 @@ def test_registry_end(helpers, seeder):
         # Test Operation Resource
         result = client.simulate_get(path=f"/operations/{op['name']}")
         assert result.status == falcon.HTTP_200
-        assert result.json["done"] == True
+        assert result.json["done"]
 
         result = client.simulate_get(path=f"/operations/{op2['name']}")
         assert result.status == falcon.HTTP_200
-        assert result.json["done"] == True
+        assert result.json["done"]
 
-        result = client.simulate_get(path=f"/operations/bad_name")
+        result = client.simulate_get(path="/operations/bad_name")
         assert result.status == falcon.HTTP_404
         assert result.json == {'title': "long running operation 'bad_name' not found"}
 
         result = client.simulate_delete(path=f"/operations/{op['name']}")
         assert result.status == falcon.HTTP_204
 
-        result = client.simulate_delete(path=f"/operations/bad_name")
+        result = client.simulate_delete(path="/operations/bad_name")
         assert result.status == falcon.HTTP_404
         assert result.json == {'title': "long running operation 'bad_name' not found"}
 
@@ -401,57 +401,57 @@ def test_credentialing_ends(helpers, seeder):
         for said in saids:
             agent.seeker.index(said)
 
-        res = client.simulate_post(f"/credentials/query")
+        res = client.simulate_post("/credentials/query")
         assert res.status_code == 200
         assert len(res.json) == 5
 
         body = json.dumps({'filter': {'-i': issuee}}).encode("utf-8")
-        res = client.simulate_post(f"/credentials/query", body=body)
+        res = client.simulate_post("/credentials/query", body=body)
         assert res.status_code == 200
         assert res.json == []
 
         body = json.dumps({'filter': {'-a-i': issuee}}).encode("utf-8")
-        res = client.simulate_post(f"/credentials/query", body=body)
+        res = client.simulate_post("/credentials/query", body=body)
         assert res.status_code == 200
         assert len(res.json) == 5
 
         body = json.dumps({'filter': {'-i': hab.pre}}).encode("utf-8")
-        res = client.simulate_post(f"/credentials/query", body=body)
+        res = client.simulate_post("/credentials/query", body=body)
         assert res.status_code == 200
         assert len(res.json) == 5
 
         body = json.dumps({'filter': {'-s': {'$eq': issuer.LE}}}).encode("utf-8")
-        res = client.simulate_post(f"/credentials/query", body=body)
+        res = client.simulate_post("/credentials/query", body=body)
         assert res.status_code == 200
         assert len(res.json) == 3
 
         body = json.dumps({'filter': {'-s': {'$eq': issuer.QVI}}}).encode("utf-8")
-        res = client.simulate_post(f"/credentials/query", body=body)
+        res = client.simulate_post("/credentials/query", body=body)
         assert res.status_code == 200
         assert len(res.json) == 2
 
         body = json.dumps({'limit': 1}).encode("utf-8")
-        res = client.simulate_post(f"/credentials/query", body=body)
+        res = client.simulate_post("/credentials/query", body=body)
         assert res.status_code == 200
         assert len(res.json) == 1
 
         body = json.dumps({'limit': 2}).encode("utf-8")
-        res = client.simulate_post(f"/credentials/query", body=body)
+        res = client.simulate_post("/credentials/query", body=body)
         assert res.status_code == 200
         assert len(res.json) == 2
 
         body = json.dumps({'limit': 4, 'skip':0}).encode("utf-8")
-        res = client.simulate_post(f"/credentials/query", body=body)
+        res = client.simulate_post("/credentials/query", body=body)
         assert res.status_code == 200
         assert len(res.json) == 4
 
         body = json.dumps({'limit': 4, 'skip':4}).encode("utf-8")
-        res = client.simulate_post(f"/credentials/query", body=body)
+        res = client.simulate_post("/credentials/query", body=body)
         assert res.status_code == 200
         assert len(res.json) == 1
 
         body = json.dumps({'limit': 4, 'skip':0, 'sort': ['-i']}).encode("utf-8")
-        res = client.simulate_post(f"/credentials/query", body=body)
+        res = client.simulate_post("/credentials/query", body=body)
         assert res.status_code == 200
         assert len(res.json) == 4
 
@@ -460,9 +460,9 @@ def test_credentialing_ends(helpers, seeder):
         assert res.headers['content-type'] == "application/json"
         assert res.json['sad']['d'] == saids[0]
 
-        res = client.simulate_get(f"/credentials/EDqDrGuzned0HOKFTLqd7m7O7WGE5zYIOHrlCq4EnWxy")
+        res = client.simulate_get("/credentials/EDqDrGuzned0HOKFTLqd7m7O7WGE5zYIOHrlCq4EnWxy")
         assert res.status_code == 404
-        assert res.json == {'description': f"credential for said EDqDrGuzned0HOKFTLqd7m7O7WGE5zYIOHrlCq4EnWxy not found.",
+        assert res.json == {'description': "credential for said EDqDrGuzned0HOKFTLqd7m7O7WGE5zYIOHrlCq4EnWxy not found.",
                             'title': '404 Not Found'}
 
         headers = {"Accept": "application/json+cesr"}
@@ -479,17 +479,17 @@ def test_credentialing_ends(helpers, seeder):
 
         res = client.simulate_get(f"/registries/{registry.regk}/EDqDrGuzned0HOKFTLqd7m7O7WGE5zYIOHrlCq4EnWxy")
         assert res.status_code == 404
-        assert res.json == {'description': f"credential EDqDrGuzned0HOKFTLqd7m7O7WGE5zYIOHrlCq4EnWxy not found in registry EACehJRd0wfteUAJgaTTJjMSaQqWvzeeHqAMMqxuqxU4",
+        assert res.json == {'description': "credential EDqDrGuzned0HOKFTLqd7m7O7WGE5zYIOHrlCq4EnWxy not found in registry EACehJRd0wfteUAJgaTTJjMSaQqWvzeeHqAMMqxuqxU4",
                             'title': '404 Not Found'}
 
         res = client.simulate_get(f"/registries/EBVaw6pCqfMIiZGkA6qevzRUGsxTRuZXxl6YG1neeCGF/{saids[0]}")
         assert res.status_code == 404
-        assert res.json == {'description': f"registry EBVaw6pCqfMIiZGkA6qevzRUGsxTRuZXxl6YG1neeCGF not found",
+        assert res.json == {'description': "registry EBVaw6pCqfMIiZGkA6qevzRUGsxTRuZXxl6YG1neeCGF not found",
                             'title': '404 Not Found'}
 
-        res = client.simulate_delete(f"/credentials/doesnotexist")
+        res = client.simulate_delete("/credentials/doesnotexist")
         assert res.status_code == 404
-        assert res.json == {'description': f"credential for said doesnotexist not found.",
+        assert res.json == {'description': "credential for said doesnotexist not found.",
                             'title': '404 Not Found'}
 
         res = client.simulate_delete(f"/credentials/{saids[0]}")
@@ -497,16 +497,16 @@ def test_credentialing_ends(helpers, seeder):
 
         res = client.simulate_get(f"/credentials/{saids[0]}")
         assert res.status_code == 404
-        assert res.json == {'description': f"credential for said EIO9uC3K6MvyjFD-RB3RYW3dfL49kCyz3OPqv3gi1dek not found.",
+        assert res.json == {'description': "credential for said EIO9uC3K6MvyjFD-RB3RYW3dfL49kCyz3OPqv3gi1dek not found.",
                             'title': '404 Not Found'}
 
-        res = client.simulate_post(f"/credentials/query")
+        res = client.simulate_post("/credentials/query")
         assert res.status_code == 200
         assert len(res.json) == 4
 
         # Query using specific filter to check indexes
         body = json.dumps({'filter': {'-a-LEI': "984500E5DEFDBQ1O9038"}}).encode("utf-8")
-        res = client.simulate_post(f"/credentials/query", body=body)
+        res = client.simulate_post("/credentials/query", body=body)
         assert res.status_code == 200
         assert len(res.json) == 0
 
@@ -610,13 +610,13 @@ def test_revoke_credential(helpers, seeder):
 
         assert agent.credentialer.complete(creder.said) is True
 
-        res = client.simulate_post(f"/credentials/query")
+        res = client.simulate_post("/credentials/query")
         assert res.status_code == 200
         assert len(res.json) == 1
         assert res.json[0]['sad']['d'] == creder.said
         assert res.json[0]['status']['s'] == "0"
 
-        res = client.simulate_post(f"/credentials/query")
+        res = client.simulate_post("/credentials/query")
         assert res.status_code == 200
         assert len(res.json) == 1
         assert res.json[0]['sad']['d'] == creder.said
@@ -676,13 +676,13 @@ def test_revoke_credential(helpers, seeder):
         while not agent.registrar.complete(creder.said, sn=1):
             doist.recur(deeds=deeds)
         
-        res = client.simulate_post(f"/credentials/query")
+        res = client.simulate_post("/credentials/query")
         assert res.status_code == 200
         assert len(res.json) == 1
         assert res.json[0]['sad']['d'] == creder.said
         assert res.json[0]['status']['s'] == "1"
 
-        res = client.simulate_post(f"/credentials/query")
+        res = client.simulate_post("/credentials/query")
         assert res.status_code == 200
         assert len(res.json) == 1
         assert res.json[0]['sad']['d'] == creder.said

--- a/tests/app/test_delegating.py
+++ b/tests/app/test_delegating.py
@@ -12,7 +12,7 @@ import pytest
 from hio.base import doing
 from keri import kering
 from keri.app import habbing
-from keri.core import coring, eventing, parsing, serdering
+from keri.core import coring, eventing, parsing
 
 from keria.app import aiding, delegating
 from keria.core import longrunning
@@ -117,7 +117,6 @@ def test_delegator_end(helpers):
         doist.recur(deeds=deeds)
         
         # normally postman would take care of this but we can do it manually here
-        teeser = teehab.kever.serder
         for msg in teehab.db.clonePreIter(pre=teehab.pre):
             parsing.Parser().parse(ims=bytearray(msg), kvy=toragent.kvy, local=True) # Local true otherwise it will be a misfit
 
@@ -149,7 +148,7 @@ def test_delegator_end(helpers):
         opResEnd = longrunning.OperationResourceEnd()
         torapp.add_route("/operations/{name}", opResEnd)
         count=0
-        while not op or not "done" in op or not op["done"]:
+        while not op or "done" not in op or not op["done"]:
             doist.recur(deeds=deeds)
             time.sleep(1)
             res = torclient.simulate_get(path=f'/operations/{op["name"]}')

--- a/tests/app/test_grouping.py
+++ b/tests/app/test_grouping.py
@@ -143,7 +143,7 @@ def test_multisig_request_ends(helpers):
         esaid = exn.ked["e"]["d"]
         agent.hby.db.meids.add(keys=(esaid,), val=coring.Saider(qb64=exn.said))
 
-        res = client.simulate_get(path=f"/multisig/request/BADSAID")
+        res = client.simulate_get(path="/multisig/request/BADSAID")
         assert res.status_code == 404
 
         res = client.simulate_get(path=f"/multisig/request/{said}")

--- a/tests/app/test_indirecting.py
+++ b/tests/app/test_indirecting.py
@@ -9,7 +9,7 @@ import falcon.testing
 from hio.help import Hict
 from keri import core
 from keri.app import habbing, httping
-from keri.core import coring, serdering
+from keri.core import serdering
 from keri.core.coring import MtrDex
 from keri.core.signing import Salter
 from keri.vdr import eventing

--- a/tests/app/test_ipexing.py
+++ b/tests/app/test_ipexing.py
@@ -215,7 +215,7 @@ def test_ipex_grant(helpers, mockHelpingNowIso8601, seeder):
 
         # Send in all signatures as if we are joining the inception event
         sigers = [signer0.sign(ser=serder.raw, index=0).qb64, signer1.sign(ser=serder.raw, index=1).qb64]
-        states = nstates = [m0['state'], m1['state']]
+        states = [m0['state'], m1['state']]
         smids = rmids = [state['i'] for state in states if 'i' in state]
 
         body = {
@@ -460,7 +460,7 @@ def test_multisig(seeder, helpers):
         assert issuerPre == "ECJg1cFrp4G2ZHk8_ocsdoS1VuptVpaG9fLktBrwx1Fo"
 
         sigers = [issuerSigner0.sign(ser=serder.raw, index=0).qb64, issuerSigner1.sign(ser=serder.raw, index=1).qb64]
-        states = nstates = [ip0['state'], ip1['state']]
+        states = [ip0['state'], ip1['state']]
         smids = rmids = [state['i'] for state in states if 'i' in state]
 
         body = {
@@ -507,9 +507,9 @@ def test_multisig(seeder, helpers):
         sigs = [issuerSigner0.sign(ser=rpy.raw, index=0).qb64, issuerSigner1.sign(ser=rpy.raw, index=1).qb64]
         body = dict(rpy=rpy.ked, sigs=sigs)
 
-        res = client0.simulate_post(path=f"/identifiers/issuer/endroles", json=body)
+        res = client0.simulate_post(path="/identifiers/issuer/endroles", json=body)
         assert res.status_code == 202
-        res = client1.simulate_post(path=f"/identifiers/issuer/endroles", json=body)
+        res = client1.simulate_post(path="/identifiers/issuer/endroles", json=body)
         assert res.status_code == 202
 
         # Create Holder Participant 0
@@ -561,7 +561,7 @@ def test_multisig(seeder, helpers):
 
         # Send in all signatures as if we are joining the inception event
         sigers = [holderSigner0.sign(ser=serder.raw, index=0).qb64, holderSigner1.sign(ser=serder.raw, index=1).qb64]
-        states = nstates = [hp0['state'], hp1['state']]
+        states = [hp0['state'], hp1['state']]
         smids = rmids = [state['i'] for state in states if 'i' in state]
         
         body = {
@@ -608,9 +608,9 @@ def test_multisig(seeder, helpers):
         sigs = [holderSigner0.sign(ser=rpy.raw, index=0).qb64, holderSigner1.sign(ser=rpy.raw, index=1).qb64]
         body = dict(rpy=rpy.ked, sigs=sigs)
 
-        res = hclient0.simulate_post(path=f"/identifiers/holder/endroles", json=body)
+        res = hclient0.simulate_post(path="/identifiers/holder/endroles", json=body)
         assert res.status_code == 202
-        res = hclient1.simulate_post(path=f"/identifiers/holder/endroles", json=body)
+        res = hclient1.simulate_post(path="/identifiers/holder/endroles", json=body)
         assert res.status_code == 202
 
         # Create Verifier Participant 0
@@ -708,9 +708,9 @@ def test_multisig(seeder, helpers):
         sigs = [verifierSigner0.sign(ser=rpy.raw, index=0).qb64, verifierSigner1.sign(ser=rpy.raw, index=1).qb64]
         body = dict(rpy=rpy.ked, sigs=sigs)
 
-        res = vclient0.simulate_post(path=f"/identifiers/verifier/endroles", json=body)
+        res = vclient0.simulate_post(path="/identifiers/verifier/endroles", json=body)
         assert res.status_code == 202
-        res = vclient1.simulate_post(path=f"/identifiers/verifier/endroles", json=body)
+        res = vclient1.simulate_post(path="/identifiers/verifier/endroles", json=body)
         assert res.status_code == 202
 
         # Introduce the multisig AIDs to each other

--- a/tests/app/test_notifying.py
+++ b/tests/app/test_notifying.py
@@ -9,7 +9,7 @@ from builtins import isinstance
 
 from keri.core.signing import Salter
 
-from keria.app import notifying, grouping
+from keria.app import notifying
 
 
 def test_load_ends(helpers):
@@ -43,7 +43,7 @@ def test_notifications(helpers):
         assert notes[0]['a'] == dict(a=1, b=2, c=3)
         assert notes[3]['a'] == dict(a=3)
 
-        headers = dict(Range=f"notes=0-2")
+        headers = dict(Range="notes=0-2")
         res = client.simulate_get(path="/notifications", headers=headers)
         assert res.status_code == 200
         notes = res.json
@@ -54,8 +54,8 @@ def test_notifications(helpers):
         assert res.headers["Content-Range"] == "notes 0-2/4"
 
         # Load since the last one seen
-        headers = dict(Range=f"notes=1-2")
-        res = client.simulate_get(path=f"/notifications", headers=headers)
+        headers = dict(Range="notes=1-2")
+        res = client.simulate_get(path="/notifications", headers=headers)
         assert res.status_code == 200
         notes = res.json
         assert len(notes) == 2

--- a/tests/core/test_authing.py
+++ b/tests/core/test_authing.py
@@ -13,7 +13,7 @@ from hio.help import Hict
 from keri import kering
 from keri import core
 from keri.app import habbing
-from keri.core import parsing, eventing, coring
+from keri.core import parsing, eventing
 from keri.end import ending
 
 from keria.app import agenting

--- a/tests/core/test_longrunning.py
+++ b/tests/core/test_longrunning.py
@@ -52,7 +52,7 @@ def test_operations(helpers):
         assert isinstance(res.json, list)
         assert len(res.json) == 0
         r = next(filter(lambda i: i["name"] == op["name"], res.json), None)
-        assert r == None
+        assert r is None
 
         # add endrole
 
@@ -60,7 +60,7 @@ def test_operations(helpers):
         sigs = helpers.sign(salt, 0, 0, rpy.raw)
         body = dict(rpy=rpy.ked, sigs=sigs)
         res = client.simulate_post(
-            path=f"/identifiers/user1/endroles", json=body)
+            path="/identifiers/user1/endroles", json=body)
         op = res.json
         assert op["done"] is True
         assert op["name"] == "endrole.EAF7geUfHm-M5lA-PI6Jv-4708a-KknnlMlA7U1_Wduv.agent.EI7AkI40M11MS7lkTCb10JC9-nDt-tXwQh44OHAFlv_9"
@@ -101,7 +101,7 @@ def test_operations(helpers):
         assert isinstance(res.json, list)
         assert len(res.json) == 1
         r = next(filter(lambda i: i["name"] == op["name"], res.json), None)
-        assert r == None
+        assert r is None
 
         # add endrole
 
@@ -109,7 +109,7 @@ def test_operations(helpers):
         sigs = helpers.sign(salt, 0, 0, rpy.raw)
         body = dict(rpy=rpy.ked, sigs=sigs)
         res = client.simulate_post(
-            path=f"/identifiers/user2/endroles", json=body)
+            path="/identifiers/user2/endroles", json=body)
         op = res.json
         assert op["done"] is True
         assert op["name"] == "endrole.EAyXphfc0qOLqEDAe0cCYCj-ovbSaEFgVgX6MrC_b5ZO.agent.EI7AkI40M11MS7lkTCb10JC9-nDt-tXwQh44OHAFlv_9"
@@ -177,7 +177,7 @@ def test_operations(helpers):
         sigs = helpers.sign(salt, 0, 0, rpy.raw)
         body = dict(rpy=rpy.ked, sigs=sigs)
         res = client.simulate_post(
-            path=f"/identifiers/user2/locschemes", json=body)
+            path="/identifiers/user2/locschemes", json=body)
         op = res.json
         assert op["done"] is True
         assert op["name"] == "locscheme.EAyXphfc0qOLqEDAe0cCYCj-ovbSaEFgVgX6MrC_b5ZO.http"
@@ -327,7 +327,7 @@ def test_error(helpers):
         assert len(res.json) == 1
 
         op = res.json[0]
-        assert op["done"] == True
+        assert op["done"]
         assert op["error"]["code"] == 500
         assert op["error"]["message"] == f"{err}"
 
@@ -335,13 +335,13 @@ def test_error(helpers):
         assert res.status_code == 500
 
         # Test other error conditions
-        res = client.simulate_get(path=f"/operations/exchange.EBfdlu8R27Fbx-ehrqwImnK-8Cm79sqbAQ4MmvEAYqao")
+        res = client.simulate_get(path="/operations/exchange.EBfdlu8R27Fbx-ehrqwImnK-8Cm79sqbAQ4MmvEAYqao")
         assert res.status_code == 404
         assert res.json == {
             'title': "long running operation 'exchange.EBfdlu8R27Fbx-ehrqwImnK-8Cm79sqbAQ4MmvEAYqao' not found"
         }
 
-        res = client.simulate_get(path=f"/operations/query.EBfdlu8R27Fbx-ehrqwImnK-8Cm79sqbAQ4MmvEAYqao")
+        res = client.simulate_get(path="/operations/query.EBfdlu8R27Fbx-ehrqwImnK-8Cm79sqbAQ4MmvEAYqao")
         assert res.status_code == 404
         assert res.json == {'title': 'long running operation '
                                      "'query.EBfdlu8R27Fbx-ehrqwImnK-8Cm79sqbAQ4MmvEAYqao' not found"}

--- a/tests/end/test_ending.py
+++ b/tests/end/test_ending.py
@@ -51,22 +51,22 @@ def test_oobi_end(helpers):
         sigs = helpers.sign(salt, 0, 0, rpy.raw)
         body = dict(rpy=rpy.ked, sigs=sigs)
 
-        res = client.simulate_post(path=f"/identifiers/aid1/endroles", json=body)
+        res = client.simulate_post(path="/identifiers/aid1/endroles", json=body)
         op = res.json
         ked = op["response"]
         serder = serdering.SerderKERI(sad=ked)
         assert serder.raw == rpy.raw
 
-        res = client.simulate_get(path=f"/oobi")
+        res = client.simulate_get(path="/oobi")
         assert res.status_code == 404
         assert res.json == {'description': 'no blind oobi for this node', 'title': '404 Not Found'}
 
-        res = client.simulate_get(path=f"/oobi/")
+        res = client.simulate_get(path="/oobi/")
         assert res.status_code == 404
         assert res.json == {'description': 'no blind oobi for this node', 'title': '404 Not Found'}
 
         # Use a bad AID
-        res = client.simulate_get(path=f"/oobi/EHXXXXXT15OJvilVvW57HE4w0-GPs_Stj2OFoAHZSys")
+        res = client.simulate_get(path="/oobi/EHXXXXXT15OJvilVvW57HE4w0-GPs_Stj2OFoAHZSys")
         assert res.status_code == 404
         assert res.json == {'description': 'AID not found for this OOBI', 'title': '404 Not Found'}
 

--- a/tests/peer/test_exchanging.py
+++ b/tests/peer/test_exchanging.py
@@ -123,12 +123,12 @@ def test_exchange_end(helpers):
         agent.exnseeker.index(exn.said)
 
         body = json.dumps({}).encode("utf-8")
-        res = client.simulate_post(f"/exchanges/query", body=body)
+        res = client.simulate_post("/exchanges/query", body=body)
         assert res.status_code == 200
         assert len(res.json) == 2
 
         body = json.dumps({'filter': {'-i': pre}, 'sort': ['-dt']}).encode("utf-8")
-        res = client.simulate_post(f"/exchanges/query", body=body)
+        res = client.simulate_post("/exchanges/query", body=body)
         assert res.status_code == 200
         assert len(res.json) == 2
 
@@ -141,7 +141,7 @@ def test_exchange_end(helpers):
         assert serder.said == exn.said
 
         body = json.dumps({'filter': {'-i': pre}, 'sort': ['-dt'], 'skip': 1, "limit": 1}).encode("utf-8")
-        res = client.simulate_post(f"/exchanges/query", body=body)
+        res = client.simulate_post("/exchanges/query", body=body)
         assert res.status_code == 200
         assert len(res.json) == 1
 
@@ -184,7 +184,7 @@ def test_exchange_end(helpers):
         agent.exnseeker.index(exn.said)
 
         body = json.dumps({'sort': ['-dt']}).encode("utf-8")
-        res = client.simulate_post(f"/exchanges/query", body=body)
+        res = client.simulate_post("/exchanges/query", body=body)
         assert res.status_code == 200
         assert len(res.json) == 3
 


### PR DESCRIPTION
Adds ruff linting with default rules (https://docs.astral.sh/ruff/rules/)

> If you're just getting started with Ruff, the default rule set is a great place to start: it catches a wide variety of common errors (like unused imports) with zero configuration.

- Removes flake8 checks to avoid having conflicting reports in the future.
  - I can add an equivalent ruff check to print warnings like this did before - but I don't see any value in it if it doesn't stop the build
     ```
     # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
     flake8 . --count --exit-zero --ignore=E7,F841,E301,E302,E303 --max-complexity=10 --max-line-length=127 --statistics
     ```
- Uses extras_require.dev to specify dev dependencies - I don't know if this is common way to specify development dependencies, but I found some examples where that is done. Please advice.
- All changes to source code are auto-fixed except: https://github.com/WebOfTrust/keria/compare/main...lenkan:keria:ruff-check?expand=1#diff-efec556acc809a758da25056e617702341fdc34bd639435343177e138c2e61a5R932