### PR TITLE
fix: GET /credentials/{said} throws 500 for escrowed credentials

### DIFF
--- a/src/keria/app/credentialing.py
+++ b/src/keria/app/credentialing.py
@@ -1030,25 +1030,26 @@ class CredentialResourceEnd:
                   application/json+cesr:
                     schema:
                         $ref: '#/components/schemas/Credential'
-           400:
+           404:
              description: The requested credential was not found.
         """
         agent = req.context.agent
         accept = req.get_header("accept")
-        try:
-            if accept == "application/json+cesr":
-                rep.content_type = "application/json+cesr"
-                data = CredentialResourceEnd.outputCred(agent.hby, agent.rgy, said)
-            else:
-                rep.content_type = "application/json"
-                creds = agent.rgy.reger.cloneCreds(
-                    [coring.Saider(qb64=said)], db=agent.hby.db
-                )
-                data = json.dumps(creds[0]).encode("utf-8")
-        except kering.MissingEntryError:
+
+        if agent.rgy.reger.saved.get(keys=(said,)) is None:
             raise falcon.HTTPNotFound(
                 description=f"credential for said {said} not found."
             )
+
+        if accept == "application/json+cesr":
+            rep.content_type = "application/json+cesr"
+            data = CredentialResourceEnd.outputCred(agent.hby, agent.rgy, said)
+        else:
+            rep.content_type = "application/json"
+            creds = agent.rgy.reger.cloneCreds(
+                [coring.Saider(qb64=said)], db=agent.hby.db
+            )
+            data = json.dumps(creds[0]).encode("utf-8")
 
         rep.status = falcon.HTTP_200
         rep.data = bytes(data)

--- a/tests/app/test_credentialing.py
+++ b/tests/app/test_credentialing.py
@@ -560,11 +560,20 @@ def test_credentialing_ends(helpers, seeder):
         res = client.simulate_get(
             "/credentials/EDqDrGuzned0HOKFTLqd7m7O7WGE5zYIOHrlCq4EnWxy"
         )
+
+        # Non-existent credential should return 404 (not found)
         assert res.status_code == 404
         assert res.json == {
             "description": "credential for said EDqDrGuzned0HOKFTLqd7m7O7WGE5zYIOHrlCq4EnWxy not found.",
             "title": "404 Not Found",
         }
+
+        # Same credential with application/json+cesr should also return 404 (not found)
+        headers = {"Accept": "application/json+cesr"}
+        res = client.simulate_get(
+            "/credentials/EDqDrGuzned0HOKFTLqd7m7O7WGE5zYIOHrlCq4EnWxy", headers=headers
+        )
+        assert res.status_code == 404
 
         headers = {"Accept": "application/json+cesr"}
         res = client.simulate_get(f"/credentials/{saids[0]}", headers=headers)
@@ -614,11 +623,17 @@ def test_credentialing_ends(helpers, seeder):
         assert res.status_code == 204
 
         res = client.simulate_get(f"/credentials/{saids[0]}")
+        # Deleted credential should return 404 (not found)
         assert res.status_code == 404
         assert res.json == {
-            "description": "credential for said EIO9uC3K6MvyjFD-RB3RYW3dfL49kCyz3OPqv3gi1dek not found.",
+            "description": f"credential for said {saids[0]} not found.",
             "title": "404 Not Found",
         }
+
+        # Deleted credential with application/json+cesr should also return 404 (not found)
+        headers = {"Accept": "application/json+cesr"}
+        res = client.simulate_get(f"/credentials/{saids[0]}", headers=headers)
+        assert res.status_code == 404
 
         res = client.simulate_post("/credentials/query")
         assert res.status_code == 200


### PR DESCRIPTION
fix: GET /credentials/{said} throws 500 for escrowed credentials https://github.com/WebOfTrust/keria/issues/400