### PR TITLE
Bugfix: tail starvation on multisig ixn anchor processing for multisig vcp/iss/rev/rpy for joiners due to missing KLI JoinDoer anchoring interaction event replay

### DIFF
--- a/src/keria/app/agenting.py
+++ b/src/keria/app/agenting.py
@@ -628,6 +628,8 @@ class Agent(doing.DoDoer):
             exchanges (Deck): exchange messages.
             grants (Deck): IPEX grant messages.
             admits (Deck): IPEX admit messages.
+            regsyncResps (Deck): registry sync response messages awaiting local application.
+            credsyncResps (Deck): credential sync response messages awaiting local application.
             submits (Deck): KEL messages to be resubmitted to witnesses to obtain receipts of.
         """
         self.agency = agency
@@ -658,6 +660,8 @@ class Agent(doing.DoDoer):
         self.exchanges = decking.Deck()
         self.grants = decking.Deck()
         self.admits = decking.Deck()
+        self.regsyncResps = decking.Deck()
+        self.credsyncResps = decking.Deck()
         self.submits = decking.Deck()
 
         receiptor = agenting.Receiptor(hby=hby)
@@ -724,6 +728,7 @@ class Agent(doing.DoDoer):
         handlers = [challengeHandler]
         self.exc = exchanging.Exchanger(hby=hby, handlers=handlers)
         grouping.loadHandlers(exc=self.exc, mux=self.mux)
+        credentialing.loadHandlers(agent=self, exc=self.exc)
         protocoling.loadHandlers(hby=self.hby, exc=self.exc, notifier=self.notifier)
         self.submitter = Submitter(
             hby=hby, submits=self.submits, witRec=self.witSubmitDoer
@@ -820,6 +825,16 @@ class Agent(doing.DoDoer):
                     exc=self.exc,
                     admits=self.admits,
                     tock=self.tocks.get("admitter", 0.0),
+                ),
+                credentialing.RegistrySyncApplyDoer(
+                    agent=self,
+                    responses=self.regsyncResps,
+                    tock=self.tocks.get("regsync", 0.0),
+                ),
+                credentialing.CredentialSyncApplyDoer(
+                    agent=self,
+                    responses=self.credsyncResps,
+                    tock=self.tocks.get("credsync", 0.0),
                 ),
                 GroupRequester(
                     hby=hby,

--- a/src/keria/app/aiding.py
+++ b/src/keria/app/aiding.py
@@ -23,6 +23,7 @@ from marshmallow import fields
 from marshmallow_dataclass import class_schema
 
 from ..core import longrunning, httping
+from .multisig import replay_multisig_embeds
 from ..utils.openapi import namedtupleToEnum, dataclassFromFielddom
 from keri.core.serdering import Protocols, Vrsn_1_0, Vrsn_2_0, SerderKERI
 
@@ -1658,6 +1659,13 @@ class EndRoleCollectionEnd:
             coring.Seqner(sn=hab.kever.sn),
             coring.Saider(qb64=hab.kever.serder.said),
             rsigers,
+        )
+        replay_multisig_embeds(
+            agent,
+            hab,
+            route="/multisig/rpy",
+            embeds=dict(rpy=rserder.ked),
+            labels=("rpy",),
         )
         try:
             agent.hby.rvy.processReply(rserder, tsgs=[tsg])

--- a/src/keria/app/credentialing.py
+++ b/src/keria/app/credentialing.py
@@ -21,6 +21,7 @@ from keri.vdr import viring
 from ..utils.openapi import dataclassFromFielddom
 from keri.core.serdering import Protocols, Vrsn_1_0, Vrsn_2_0, SerderKERI
 from ..core import httping, longrunning
+from .multisig import replay_multisig_embeds
 from marshmallow import fields, Schema as MarshmallowSchema
 from typing import List, Dict, Any, Optional, Tuple, Literal, Union
 from .aiding import (
@@ -39,63 +40,6 @@ from .aiding import (
 
 
 logger = help.ogler.getLogger()
-
-
-def replay_multisig_embeds(agent, hab, *, route, embeds, labels):
-    """Replay previously stored non-local multisig embedded events before a
-    Signify follower's local approval of multisig group messages such as
-    `/multisig/vcp` (registry inception) and `/multisig/iss`
-    (credential issuance).
-
-    Signify clients approve `/multisig/vcp` and `/multisig/iss` by later
-    submitting the embedded events directly to the credentialing endpoints.
-
-    KLI join flows explicitly parse the initiator's signed anchoring event from
-    the stored multisig EXN before parsing the follower's approval of that same
-    event. Original KERIA follower approval did not do this for
-    local-after-remote ordering, so the follower could approve second without
-    first ingesting the remote participant's signed embedded event attachments.
-
-    This helper reconstructs the embedded-section SAID from the submitted
-    approval payload, finds matching stored non-local EXNs, and replays the
-    requested embedded events plus pathed attachments through the parser in the
-    same order KLI uses.
-
-    Terminology note:
-    The ``labels`` argument is expressed in EXN embed-label terms, not concrete
-    event-type terms. For example, the multisig protocol uses the embed label
-    ``anc`` for the anchoring KEL event even when the actual event body is an
-    interaction event (``ixn``).
-    """
-    if not isinstance(hab, SignifyGroupHab):
-        return 0
-
-    embed_ked = {label: embeds[label] for label in embeds}
-    embed_ked["d"] = ""
-    _, embed_ked = coring.Saider.saidify(sad=embed_ked, label=coring.Saids.d)
-
-    replays = 0
-    # Replay stored non-local embedded events and their pathed attachments
-    # before local follower approval. This restores the KLI join ordering for
-    # local-after-remote Signify approval flows.
-    for msg in agent.mux.get(esaid=embed_ked["d"]):
-        exn = msg["exn"]
-        if exn["r"] != route or exn["i"] == hab.mhab.pre:
-            continue
-
-        paths = msg["paths"]
-        for label in labels:
-            if label not in paths:
-                continue
-
-            sadder = coring.Sadder(ked=embeds[label])
-            ims = bytearray(sadder.raw)
-            ims.extend(paths[label].encode("utf-8"))
-            agent.hby.psr.parseOne(ims=ims)
-
-        replays += 1
-
-    return replays
 
 
 def loadEnds(app, identifierResource):
@@ -1019,6 +963,14 @@ class CredentialCollectionEnd:
                 description=f"issue against invalid registry SAID {regk}"
             )
 
+        replay_multisig_embeds(
+            agent,
+            hab,
+            route="/multisig/iss",
+            embeds=dict(acdc=creder.sad, iss=iserder.ked, anc=anc.ked),
+            labels=("anc", "acdc"),
+        )
+
         if hab.kever.estOnly:
             op = self.identifierResource.rotate(agent, name, body)
         else:
@@ -1314,14 +1266,25 @@ class CredentialResourceDeleteEnd:
             )
 
         if hab.kever.estOnly:
+            anc = serdering.SerderKERI(sad=httping.getRequiredParam(body, "rot"))
+        else:
+            anc = serdering.SerderKERI(sad=httping.getRequiredParam(body, "ixn"))
+
+        replay_multisig_embeds(
+            agent,
+            hab,
+            route="/multisig/rev",
+            embeds=dict(rev=rserder.ked, anc=anc.ked),
+            labels=("anc",),
+        )
+
+        if hab.kever.estOnly:
             op = self.identifierResource.rotate(agent, name, body)
-            anc = httping.getRequiredParam(body, "rot")
         else:
             op = self.identifierResource.interact(agent, name, body)
-            anc = httping.getRequiredParam(body, "ixn")
 
         try:
-            agent.registrar.revoke(regk, rserder, anc)
+            agent.registrar.revoke(regk, rserder, anc.ked)
         except Exception:
             raise falcon.HTTPBadRequest(description="invalid revocation event.")
 
@@ -1515,6 +1478,9 @@ class Registrar:
             seqner = coring.Seqner(sn=sn)
             saider = coring.Saider(qb64=said)
 
+            self.counselor.start(
+                prefixer=prefixer, seqner=seqner, saider=saider, ghab=hab
+            )
             logger.info(
                 "[%s | %s]: Waiting for TEL iss event mulisig anchoring event %s",
                 hab.name,

--- a/src/keria/app/credentialing.py
+++ b/src/keria/app/credentialing.py
@@ -41,6 +41,63 @@ from .aiding import (
 logger = help.ogler.getLogger()
 
 
+def replay_multisig_embeds(agent, hab, *, route, embeds, labels):
+    """Replay previously stored non-local multisig embedded events before a
+    Signify follower's local approval of multisig group messages such as
+    `/multisig/vcp` (registry inception) and `/multisig/iss`
+    (credential issuance).
+
+    Signify clients approve `/multisig/vcp` and `/multisig/iss` by later
+    submitting the embedded events directly to the credentialing endpoints.
+
+    KLI join flows explicitly parse the initiator's signed anchoring event from
+    the stored multisig EXN before parsing the follower's approval of that same
+    event. Original KERIA follower approval did not do this for
+    local-after-remote ordering, so the follower could approve second without
+    first ingesting the remote participant's signed embedded event attachments.
+
+    This helper reconstructs the embedded-section SAID from the submitted
+    approval payload, finds matching stored non-local EXNs, and replays the
+    requested embedded events plus pathed attachments through the parser in the
+    same order KLI uses.
+
+    Terminology note:
+    The ``labels`` argument is expressed in EXN embed-label terms, not concrete
+    event-type terms. For example, the multisig protocol uses the embed label
+    ``anc`` for the anchoring KEL event even when the actual event body is an
+    interaction event (``ixn``).
+    """
+    if not isinstance(hab, SignifyGroupHab):
+        return 0
+
+    embed_ked = {label: embeds[label] for label in embeds}
+    embed_ked["d"] = ""
+    _, embed_ked = coring.Saider.saidify(sad=embed_ked, label=coring.Saids.d)
+
+    replays = 0
+    # Replay stored non-local embedded events and their pathed attachments
+    # before local follower approval. This restores the KLI join ordering for
+    # local-after-remote Signify approval flows.
+    for msg in agent.mux.get(esaid=embed_ked["d"]):
+        exn = msg["exn"]
+        if exn["r"] != route or exn["i"] == hab.mhab.pre:
+            continue
+
+        paths = msg["paths"]
+        for label in labels:
+            if label not in paths:
+                continue
+
+            sadder = coring.Sadder(ked=embeds[label])
+            ims = bytearray(sadder.raw)
+            ims.extend(paths[label].encode("utf-8"))
+            agent.hby.psr.parseOne(ims=ims)
+
+        replays += 1
+
+    return replays
+
+
 def loadEnds(app, identifierResource):
     schemaColEnd = SchemaCollectionEnd()
     app.add_route("/schema", schemaColEnd)
@@ -392,6 +449,17 @@ class RegistryCollectionEnd:
             )
 
         registry = agent.rgy.makeSignifyRegistry(name=rname, prefix=hab.pre, regser=vcp)
+
+        # The `/multisig/vcp` EXN uses the embed label `anc` for the anchoring
+        # KEL event. In this endpoint that concrete event is the submitted `ixn`.
+        protocol_embeds = dict(vcp=vcp.ked, anc=ixn.ked)
+        replay_multisig_embeds(
+            agent,
+            hab,
+            route="/multisig/vcp",
+            embeds=protocol_embeds,
+            labels=("anc",),
+        )
 
         if hab.kever.estOnly:
             op = self.identifierResource.rotate(agent, name, body)
@@ -1392,6 +1460,10 @@ class Registrar:
             )
 
         else:
+            # assume SignifyGroupHab - multisig incept, so start the counselor to wait on multisig incept completion
+            self.counselor.start(
+                ghab=hab, prefixer=prefixer, seqner=seqner, saider=saider
+            )
             logger.info(
                 "[%s | %s]: Waiting for TEL registry vcp event mulisig anchoring event",
                 hab.name,

--- a/src/keria/app/credentialing.py
+++ b/src/keria/app/credentialing.py
@@ -10,13 +10,16 @@ import json
 from dataclasses import asdict, dataclass, field
 
 import falcon
+from hio.base import doing
 from keri import kering, help
-from keri.app import signing
+from keri.app import signing, grouping as keri_grouping
 from keri.app.habbing import SignifyGroupHab
 from keri.core import coring, scheming, serdering
 from keri.db import dbing
 from keri.db.dbing import dgKey
-from keri.vdr import viring
+from keri.help import helping
+from keri.peer import exchanging
+from keri.vdr import viring, credentialing as vdr_credentialing
 
 from ..utils.openapi import dataclassFromFielddom
 from keri.core.serdering import Protocols, Vrsn_1_0, Vrsn_2_0, SerderKERI
@@ -50,12 +53,16 @@ def loadEnds(app, identifierResource):
 
     registryEnd = RegistryCollectionEnd(identifierResource)
     app.add_route("/identifiers/{name}/registries", registryEnd)
+    registrySyncEnd = RegistrySyncCollectionEnd()
+    app.add_route("/identifiers/{name}/registries/sync", registrySyncEnd)
 
     registryResEnd = RegistryResourceEnd()
     app.add_route("/identifiers/{name}/registries/{registryName}", registryResEnd)
 
     credentialCollectionEnd = CredentialCollectionEnd(identifierResource)
     app.add_route("/identifiers/{name}/credentials", credentialCollectionEnd)
+    credentialSyncEnd = CredentialSyncCollectionEnd()
+    app.add_route("/identifiers/{name}/credentials/sync", credentialSyncEnd)
 
     credentialRegistryResEnd = CredentialRegistryResourceEnd()
     app.add_route("/registries/{ri}/{vci}", credentialRegistryResEnd)
@@ -70,6 +77,466 @@ def loadEnds(app, identifierResource):
 
     credentialVerificationEnd = CredentialVerificationCollectionEnd()
     app.add_route("/credentials/verify", credentialVerificationEnd)
+
+
+def loadHandlers(agent, exc):
+    """Register machine-handled EXN routes for late-join sync workflows."""
+    exc.addHandler(RegistrySyncRequestHandler(agent=agent))
+    exc.addHandler(RegistrySyncResponseHandler(agent=agent))
+    exc.addHandler(CredentialSyncRequestHandler(agent=agent))
+    exc.addHandler(CredentialSyncResponseHandler(agent=agent))
+
+
+def _resolve_identifier(agent, name):
+    return agent.hby.habs[name] if name in agent.hby.habs else agent.hby.habByName(name)
+
+
+def _resolve_group_identifier(agent, name):
+    hab = _resolve_identifier(agent, name)
+    if hab is None:
+        raise falcon.HTTPNotFound(
+            description=f"{name} is not a valid reference to an identifier"
+        )
+    if not isinstance(hab, SignifyGroupHab):
+        raise falcon.HTTPConflict(
+            description=f"hab for alias or prefix {name} is not a multisig"
+        )
+    return hab
+
+
+def _has_endpoint(agent, aid):
+    ends = agent.agentHab.endsFor(aid)
+    for role_ends in ends.values():
+        for locs in role_ends.values():
+            if locs:
+                return True
+    return False
+
+
+def _agent_authorized_for_member(agent, member, eid):
+    return eid in agent.agentHab.endsFor(member).get("agent", {})
+
+
+def _eligible_regsync_sources(agent, hab):
+    members = hab.db.signingMembers(pre=hab.pre) or []
+    eligible = [
+        member
+        for member in sorted(members)
+        if member != hab.mhab.pre and member in agent.hby.kevers and _has_endpoint(agent, member)
+    ]
+    return eligible
+
+
+def _select_regsync_source(agent, hab, source=None):
+    eligible = _eligible_regsync_sources(agent, hab)
+    if source is None:
+        if not eligible:
+            raise falcon.HTTPConflict(
+                description=f"no eligible registry sync sources found for {hab.pre}"
+            )
+        return eligible[0]
+
+    try:
+        coring.Prefixer(qb64=source)
+    except kering.ValidationError as ex:
+        raise falcon.HTTPBadRequest(description=str(ex)) from ex
+
+    if source not in eligible:
+        raise falcon.HTTPConflict(
+            description=f"{source} is not an eligible registry sync source for {hab.pre}"
+        )
+
+    return source
+
+
+def _sync_op_name(optype, pre):
+    return f"{optype}.{pre}"
+
+
+def _regsync_op_name(pre):
+    return _sync_op_name(longrunning.OpTypes.regsync, pre)
+
+
+def _credsync_op_name(pre):
+    return _sync_op_name(longrunning.OpTypes.credsync, pre)
+
+
+def _update_sync_error(agent, name, code, message, details=None):
+    op = agent.monitor.opr.ops.get(keys=(name,))
+    if op is None:
+        return
+
+    metadata = dict(op.metadata)
+    metadata["error"] = dict(code=code, message=message, details=details)
+    agent.monitor.update(name, metadata=metadata)
+
+
+def _update_regsync_error(agent, name, code, message, details=None):
+    _update_sync_error(agent, name, code, message, details=details)
+
+
+def _update_credsync_error(agent, name, code, message, details=None):
+    _update_sync_error(agent, name, code, message, details=details)
+
+
+def _find_sync_by_request(agent, request_said, optype):
+    for _, op in agent.monitor.opr.ops.getItemIter():
+        if op.type != optype:
+            continue
+        if op.metadata.get("request") != request_said:
+            continue
+        return _sync_op_name(op.type, op.oid), op
+
+    return None, None
+
+
+def _find_regsync_by_request(agent, request_said):
+    return _find_sync_by_request(agent, request_said, longrunning.OpTypes.regsync)
+
+
+def _find_credsync_by_request(agent, request_said):
+    return _find_sync_by_request(agent, request_said, longrunning.OpTypes.credsync)
+
+
+def _current_credential_regk(creder):
+    if getattr(creder, "regi", None) is not None:
+        return creder.regi
+
+    sad = creder.sad if hasattr(creder, "sad") else creder
+    if sad.get("ri") is not None:
+        return sad["ri"]
+    if sad.get("rd") is not None:
+        return sad["rd"]
+
+    return None
+
+
+def _materialize_signify_registry(agent, name, prefix, regk):
+    hab = agent.hby.habs[prefix]
+    if hab is None:
+        raise kering.ConfigurationError(
+            f"Unknown prefix {prefix} for creating Registry {name}"
+        )
+
+    registry = vdr_credentialing.SignifyRegistry(
+        hab=hab,
+        name=name,
+        reger=agent.rgy.reger,
+        tvy=agent.rgy.tvy,
+        psr=agent.rgy.psr,
+        cues=agent.rgy.cues,
+        regk=regk,
+    )
+    registry.inited = True
+
+    agent.rgy.reger.regs.put(
+        keys=name,
+        val=viring.RegistryRecord(registryKey=regk, prefix=prefix),
+    )
+    agent.rgy.reger.registries.add(regk)
+    agent.rgy.regs[regk] = registry
+
+    return registry
+
+
+def _validate_sync_saids(body):
+    saids = body.get("saids")
+    if not isinstance(saids, list) or len(saids) == 0:
+        raise falcon.HTTPBadRequest(
+            description="'saids' is required and must be a non-empty list"
+        )
+
+    deduped = []
+    seen = set()
+    for said in saids:
+        if not isinstance(said, str):
+            raise falcon.HTTPBadRequest(
+                description="'saids' entries must be qb64 credential SAIDs"
+            )
+        try:
+            coring.Saider(qb64=said)
+        except kering.ValidationError as ex:
+            raise falcon.HTTPBadRequest(description=str(ex)) from ex
+
+        if said in seen:
+            continue
+
+        seen.add(said)
+        deduped.append(said)
+
+    return deduped
+
+
+def _registry_sync_request_exn(hab, gid, mid=None):
+    helper = getattr(keri_grouping, "multisigRegistrySyncRequestExn", None)
+    if helper is not None and mid is None:
+        return helper(hab=hab, gid=gid)
+
+    payload = dict(gid=gid)
+    if mid is not None:
+        payload["mid"] = mid
+
+    exn, end = exchanging.exchange(
+        route="/multisig/registry/sync",
+        payload=payload,
+        sender=hab.pre,
+    )
+    evt = hab.endorse(serder=exn, last=False, pipelined=False)
+    atc = bytearray(evt[exn.size:])
+    atc.extend(end)
+    return exn, atc
+
+
+def _credential_sync_request_exn(hab, gid, saids, mid=None):
+    helper = getattr(keri_grouping, "multisigCredentialSyncRequestExn", None)
+    if helper is not None:
+        try:
+            return helper(hab=hab, gid=gid, saids=saids, mid=mid)
+        except TypeError:
+            pass
+
+    payload = dict(gid=gid, saids=saids)
+    if mid is not None:
+        payload["mid"] = mid
+
+    exn, end = exchanging.exchange(
+        route="/multisig/credential/sync",
+        payload=payload,
+        sender=hab.pre,
+    )
+    evt = hab.endorse(serder=exn, last=False, pipelined=False)
+    atc = bytearray(evt[exn.size:])
+    atc.extend(end)
+    return exn, atc
+
+
+def _registry_sync_response_exn(hab, gid, registries, dig, history=None, messages=None):
+    helper = getattr(keri_grouping, "multisigRegistrySyncResponseExn", None)
+    if helper is not None and history is None and messages is None:
+        try:
+            return helper(
+                hab=hab,
+                gid=gid,
+                registries=registries,
+                dig=dig,
+            )
+        except TypeError:
+            return helper(hab=hab, gid=gid, registries=registries, dig=dig)
+
+    if messages is not None:
+        embeds = _message_embeds(messages, prefix="vcpmsg")
+    else:
+        embeds = dict(history=history) if history is not None else None
+
+    exn, end = exchanging.exchange(
+        route="/multisig/registry/sync/response",
+        payload=dict(gid=gid, registries=registries),
+        sender=hab.pre,
+        dig=dig,
+        embeds=embeds,
+    )
+    evt = hab.endorse(serder=exn, last=False, pipelined=False)
+    atc = bytearray(evt[exn.size:])
+    atc.extend(end)
+    return exn, atc
+
+
+def _credential_sync_response_exn(
+    hab,
+    gid,
+    said,
+    dig,
+    credential=None,
+    error=None,
+    messages=None,
+    schemas=None,
+):
+    helper = getattr(keri_grouping, "multisigCredentialSyncResponseExn", None)
+    if helper is not None and error is None and messages is None:
+        try:
+            return helper(hab=hab, gid=gid, said=said, credential=credential, dig=dig)
+        except TypeError:
+            pass
+
+    payload = dict(gid=gid, said=said)
+    if error is not None:
+        payload["error"] = error
+    if schemas is not None:
+        payload["schemas"] = schemas
+
+    if messages is not None:
+        embeds = _message_embeds(messages, prefix="credmsg")
+    else:
+        embeds = dict(cred=credential) if credential is not None else None
+    exn, end = exchanging.exchange(
+        route="/multisig/credential/sync/response",
+        payload=payload,
+        sender=hab.pre,
+        dig=dig,
+        embeds=embeds,
+    )
+    evt = hab.endorse(serder=exn, last=False, pipelined=False)
+    atc = bytearray(evt[exn.size:])
+    atc.extend(end)
+    return exn, atc
+
+
+def _embedded_stream_from_attachments(serder, attachments, label):
+    embeds = serder.ked.get("e", {})
+    if label not in embeds:
+        return None
+
+    if attachments:
+        for pather, atc in attachments:
+            if not pather.path or pather.path[0] != label:
+                continue
+
+            ked = pather.resolve(embeds)
+            sadder = coring.Sadder(ked=ked)
+            ims = bytearray(sadder.raw)
+            ims.extend(atc)
+            return ims
+
+    return bytearray(coring.Sadder(ked=embeds[label]).raw)
+
+
+def _embedded_messages_from_attachments(serder, attachments, prefix):
+    embeds = serder.ked.get("e", {})
+    labels = sorted(
+        label for label in embeds.keys() if label != "d" and label.startswith(prefix)
+    )
+
+    if not labels:
+        return []
+
+    attachment_map = {}
+    for pather, atc in attachments:
+        if not pather.path:
+            continue
+
+        attachment_map[pather.path[0]] = atc
+
+    messages = []
+    for label in labels:
+        ims = bytearray(coring.Sadder(ked=embeds[label]).raw)
+        if label in attachment_map:
+            ims.extend(attachment_map[label])
+        messages.append(ims)
+
+    return messages
+
+
+def _credential_chain_saids(creder):
+    chains = creder.edge or dict()
+    saids = []
+    for key, source in chains.items():
+        if key == "d":
+            continue
+
+        if not isinstance(source, dict):
+            continue
+
+        saids.append(source["n"])
+
+    return saids
+
+
+def _message_embeds(messages, prefix):
+    return {
+        f"{prefix}{idx:04d}": bytes(message)
+        for idx, message in enumerate(messages)
+    }
+
+
+def _credential_sync_messages(hby, rgy, said, seen=None):
+    seen = set() if seen is None else seen
+    if said in seen:
+        return []
+
+    seen.add(said)
+    messages = []
+    creder, prefixer, seqner, saider = rgy.reger.cloneCred(said=said)
+    for chain_said in _credential_chain_saids(creder):
+        messages.extend(_credential_sync_messages(hby, rgy, chain_said, seen=seen))
+
+    for msg in hby.db.clonePreIter(pre=creder.issuer):
+        messages.append(bytes(msg))
+
+    if "i" in creder.attrib:
+        subj = creder.attrib["i"]
+        for msg in hby.db.clonePreIter(pre=subj):
+            messages.append(bytes(msg))
+
+    if creder.regi is not None:
+        for msg in rgy.reger.clonePreIter(pre=creder.regi):
+            messages.append(bytes(msg))
+
+        for msg in rgy.reger.clonePreIter(pre=creder.said):
+            messages.append(bytes(msg))
+
+    messages.append(bytes(signing.serialize(creder, prefixer, seqner, saider)))
+    return messages
+
+
+def _credential_sync_schemas(hby, rgy, said, seen=None):
+    seen = set() if seen is None else seen
+    if said in seen:
+        return []
+
+    seen.add(said)
+    schemas = []
+    creder, _, _, _ = rgy.reger.cloneCred(said=said)
+    for chain_said in _credential_chain_saids(creder):
+        schemas.extend(_credential_sync_schemas(hby, rgy, chain_said, seen=seen))
+
+    if (schemer := hby.db.schema.get(creder.schema)) is not None:
+        schemas.append(dict(schemer.sed))
+
+    return schemas
+
+
+def _registry_anchor(regk, regd, sn="0"):
+    return dict(i=regk, s=sn, d=regd)
+
+
+def _query_group_anchor_for_tel_message(agent, gid, group_hab, message):
+    """Backfill or query the group KEL event that seals a synced TEL message."""
+
+    try:
+        serder = SerderKERI(raw=bytes(message))
+    except Exception:
+        return
+
+    if serder.ked.get("t") not in {"vcp", "vrt", "iss", "bis", "rev", "brv"}:
+        return
+
+    seal = dict(i=serder.pre, s=serder.snh, d=serder.said)
+    if longrunning.ensure_tel_anchor(
+        hby=agent.hby,
+        reger=agent.rgy.reger,
+        gid=gid,
+        pre=serder.pre,
+        said=serder.said,
+        anchor=seal,
+    ):
+        return
+
+    agent.witq.query(
+        hab=agent.agentHab,
+        pre=gid,
+        anchor=seal,
+        wits=group_hab.kever.wits or None,
+    )
+
+
+def _cache_embedded_schemas(agent, serder, attachments):
+    payload = serder.ked.get("a", {})
+    schemas = payload.get("schemas", [])
+    for sed in schemas:
+        schemer = scheming.Schemer(sed=sed)
+        agent.verifier.resolver.add(schemer.said, schemer.raw)
+
+    return schemas
 
 
 class EmptyDictSchema(MarshmallowSchema):
@@ -430,6 +897,735 @@ class RegistryCollectionEnd:
 
         rep.status = falcon.HTTP_202
         rep.data = op.to_json().encode("utf-8")
+
+
+class RegistrySyncCollectionEnd:
+    """Collection endpoint for explicit multisig registry catch-up."""
+
+    @staticmethod
+    def on_post(req, rep, name):
+        agent = req.context.agent
+        body = req.get_media() or {}
+        if not isinstance(body, dict):
+            raise falcon.HTTPBadRequest(description="body must be a JSON object")
+
+        hab = _resolve_group_identifier(agent, name)
+        source = _select_regsync_source(agent, hab, source=body.get("source"))
+
+        opname = _regsync_op_name(hab.pre)
+        if (existing := agent.monitor.opr.ops.get(keys=(opname,))) is not None:
+            if not agent.monitor.status(existing).done:
+                raise falcon.HTTPConflict(
+                    description=f"registry sync already pending for {hab.pre}"
+                )
+
+        exn, atc = _registry_sync_request_exn(
+            hab=agent.agentHab,
+            gid=hab.pre,
+            mid=hab.mhab.pre,
+        )
+        agent.hby.psr.parseOne(
+            ims=bytearray(exn.raw) + bytearray(atc),
+            exc=agent.exc,
+        )
+
+        metadata = dict(
+            pre=hab.pre,
+            source=source,
+            phase="catalog",
+            phase_start=helping.nowIso8601(),
+            request=exn.said,
+            targets=[],
+            error=None,
+        )
+        op = agent.monitor.submit(hab.pre, longrunning.OpTypes.regsync, metadata=metadata)
+        agent.exchanges.append(
+            dict(said=exn.said, pre=agent.agentHab.pre, rec=[source], topic="multisig")
+        )
+
+        rep.status = falcon.HTTP_202
+        rep.data = op.to_json().encode("utf-8")
+
+
+class CredentialSyncCollectionEnd:
+    """Collection endpoint for explicit multisig credential-history catch-up."""
+
+    @staticmethod
+    def on_post(req, rep, name):
+        agent = req.context.agent
+        body = req.get_media() or {}
+        if not isinstance(body, dict):
+            raise falcon.HTTPBadRequest(description="body must be a JSON object")
+
+        hab = _resolve_group_identifier(agent, name)
+        saids = _validate_sync_saids(body)
+        source = _select_regsync_source(agent, hab, source=body.get("source"))
+
+        if not any(registry.hab.pre == hab.pre for registry in agent.rgy.regs.values()):
+            raise falcon.HTTPConflict(
+                description=f"credential sync for {hab.pre} requires registry sync first"
+            )
+
+        opname = _credsync_op_name(hab.pre)
+        if (existing := agent.monitor.opr.ops.get(keys=(opname,))) is not None:
+            if not agent.monitor.status(existing).done:
+                raise falcon.HTTPConflict(
+                    description=f"credential sync already pending for {hab.pre}"
+                )
+
+        exn, atc = _credential_sync_request_exn(
+            hab=agent.agentHab,
+            gid=hab.pre,
+            saids=saids,
+            mid=hab.mhab.pre,
+        )
+        agent.hby.psr.parseOne(
+            ims=bytearray(exn.raw) + bytearray(atc),
+            exc=agent.exc,
+        )
+
+        metadata = dict(
+            pre=hab.pre,
+            source=source,
+            phase="replay",
+            phase_start=helping.nowIso8601(),
+            request=exn.said,
+            saids=saids,
+            synced=[],
+            error=None,
+        )
+        op = agent.monitor.submit(hab.pre, longrunning.OpTypes.credsync, metadata=metadata)
+        agent.exchanges.append(
+            dict(said=exn.said, pre=agent.agentHab.pre, rec=[source], topic="multisig")
+        )
+
+        rep.status = falcon.HTTP_202
+        rep.data = op.to_json().encode("utf-8")
+
+
+class RegistrySyncRequestHandler:
+    """Machine-handled multisig registry sync request."""
+
+    resource = "/multisig/registry/sync"
+
+    def __init__(self, agent):
+        self.agent = agent
+
+    def handle(self, serder, attachments=None):
+        payload = serder.ked.get("a", {})
+        gid = payload.get("gid")
+        sender = serder.ked.get("i")
+        requester = payload.get("mid")
+        if gid is None or sender is None:
+            logger.error("invalid registry sync request payload on %s", serder.said)
+            return
+
+        hab = self.agent.hby.habByPre(gid)
+        if hab is None or not isinstance(hab, SignifyGroupHab):
+            logger.info("ignoring registry sync request for unknown group %s", gid)
+            return
+
+        members = hab.db.signingMembers(pre=gid) or []
+        if requester is not None:
+            if requester not in members:
+                logger.warning(
+                    "ignoring registry sync request %s for non-member requester %s on %s",
+                    serder.said,
+                    requester,
+                    gid,
+                )
+                return
+            if not _agent_authorized_for_member(self.agent, requester, sender):
+                logger.warning(
+                    "ignoring registry sync request %s from unauthorized agent %s for %s",
+                    serder.said,
+                    sender,
+                    requester,
+                )
+                return
+            if requester == hab.mhab.pre and sender == self.agent.agentHab.pre:
+                logger.info(
+                    "ignoring locally originated registry sync request %s for %s",
+                    serder.said,
+                    gid,
+                )
+                return
+        elif not any(_agent_authorized_for_member(self.agent, member, sender) for member in members):
+            logger.warning(
+                "ignoring registry sync request %s from non-member agent %s for %s",
+                serder.said,
+                sender,
+                gid,
+            )
+            return
+
+        registries = []
+        messages = []
+        local_regs = sorted(
+            self.agent.rgy.regs.values(),
+            key=lambda registry: (registry.name, registry.regk),
+        )
+        for registry in local_regs:
+            if registry.hab.pre != gid or registry.regk not in self.agent.rgy.tevers:
+                continue
+            vcp = SerderKERI(raw=self.agent.rgy.reger.cloneTvtAt(pre=registry.regk, sn=0))
+            vcp_message = None
+            for msg in self.agent.rgy.reger.clonePreIter(pre=registry.regk, fn=0):
+                vcp_message = bytes(msg)
+                break
+
+            if vcp_message is None:
+                logger.warning(
+                    "skipping registry %s during sync for %s because no VCP replay message was available",
+                    registry.regk,
+                    gid,
+                )
+                continue
+
+            registries.append(
+                dict(
+                    name=registry.name,
+                    regk=registry.regk,
+                    vcp=vcp.ked,
+                    anc=_registry_anchor(registry.regk, vcp.said, sn=vcp.snh),
+                    sn=registry.tever.sn,
+                )
+            )
+            messages.append(vcp_message)
+
+        exn, atc = _registry_sync_response_exn(
+            hab=self.agent.agentHab,
+            gid=gid,
+            registries=registries,
+            dig=serder.said,
+            messages=messages,
+        )
+        self.agent.hby.psr.parseOne(
+            ims=bytearray(exn.raw) + bytearray(atc),
+            exc=self.agent.exc,
+        )
+        self.agent.exchanges.append(
+            dict(
+                said=exn.said,
+                pre=self.agent.agentHab.pre,
+                rec=[requester if requester is not None else sender],
+                topic="multisig",
+            )
+        )
+
+
+class RegistrySyncResponseHandler:
+    """Machine-handled multisig registry sync response."""
+
+    resource = "/multisig/registry/sync/response"
+
+    def __init__(self, agent):
+        self.agent = agent
+
+    def handle(self, serder, attachments=None):
+        self.agent.regsyncResps.append(
+            dict(serder=serder, attachments=attachments or [])
+        )
+
+
+class RegistrySyncApplyDoer(doing.Doer):
+    """Apply sync responses by hydrating local registry records then replaying TEL."""
+
+    def __init__(self, agent, responses, tock=0.0):
+        self.agent = agent
+        self.responses = responses
+        self.tock = tock
+        super(RegistrySyncApplyDoer, self).__init__(tock=tock)
+
+    def recur(self, tyme=None, tock=0.0, **opts):
+        if not self.responses:
+            return False
+
+        msg = self.responses.popleft()
+        serder = msg["serder"]
+        attachments = msg.get("attachments") or []
+        request_said = serder.ked.get("p")
+        if not request_said:
+            logger.warning("ignoring registry sync response %s without p", serder.said)
+            return False
+
+        opname, op = _find_regsync_by_request(self.agent, request_said)
+        if op is None:
+            logger.info(
+                "ignoring stale registry sync response %s for request %s",
+                serder.said,
+                request_said,
+            )
+            return False
+
+        metadata = dict(op.metadata)
+        source = metadata["source"]
+        gid = metadata["pre"]
+        payload = serder.ked.get("a", {})
+        sender = serder.ked.get("i")
+        if sender is None or not _agent_authorized_for_member(self.agent, source, sender):
+            _update_regsync_error(
+                self.agent,
+                opname,
+                424,
+                f"registry sync response source mismatch, expected agent for {source} got {sender}",
+            )
+            return False
+
+        if payload.get("gid") != gid:
+            _update_regsync_error(
+                self.agent,
+                opname,
+                424,
+                f"registry sync response group mismatch, expected {gid} got {payload.get('gid')}",
+            )
+            return False
+
+        if metadata["phase"] != "catalog":
+            logger.info(
+                "ignoring registry sync response %s for completed phase %s",
+                serder.said,
+                metadata["phase"],
+            )
+            return False
+
+        entries = payload.get("registries")
+        if not isinstance(entries, list):
+            _update_regsync_error(
+                self.agent,
+                opname,
+                424,
+                "registry sync response registries payload must be a list",
+            )
+            return False
+
+        vcp_messages = _embedded_messages_from_attachments(serder, attachments, "vcpmsg")
+        if vcp_messages and len(vcp_messages) != len(entries):
+            _update_regsync_error(
+                self.agent,
+                opname,
+                424,
+                "registry sync response VCP message count does not match registry entries",
+                details=dict(entries=len(entries), messages=len(vcp_messages)),
+            )
+            return False
+
+        parsed = []
+        for idx, entry in enumerate(entries):
+            if not isinstance(entry, dict):
+                _update_regsync_error(
+                    self.agent,
+                    opname,
+                    424,
+                    "registry sync response contains a non-object registry entry",
+                    details=dict(entry=entry),
+                )
+                return False
+
+            try:
+                name = entry["name"]
+                regk = entry["regk"]
+                vcp = SerderKERI(sad=entry["vcp"])
+                anc = entry["anc"]
+                sn = int(entry["sn"])
+                coring.Prefixer(qb64=regk)
+            except (KeyError, TypeError, ValueError, kering.ValidationError) as ex:
+                _update_regsync_error(
+                    self.agent,
+                    opname,
+                    424,
+                    f"invalid registry sync response entry: {ex}",
+                    details=dict(entry=entry),
+                )
+                return False
+
+            existing_by_name = self.agent.rgy.registryByName(name)
+            if existing_by_name is not None and existing_by_name.regk != regk:
+                _update_regsync_error(
+                    self.agent,
+                    opname,
+                    409,
+                    f"registry name {name} already maps to {existing_by_name.regk}",
+                    details=dict(name=name, regk=regk, existing=existing_by_name.regk),
+                )
+                return False
+
+            if vcp.ked["t"] != "vcp" or vcp.pre != regk:
+                _update_regsync_error(
+                    self.agent,
+                    opname,
+                    424,
+                    f"invalid registry inception event for {regk}",
+                    details=dict(entry=entry),
+                )
+                return False
+
+            if tuple(anc) != ("i", "s", "d"):
+                _update_regsync_error(
+                    self.agent,
+                    opname,
+                    424,
+                    f"invalid registry sync anchor for {regk}",
+                    details=dict(entry=entry),
+                )
+                return False
+
+            parsed.append(
+                (name, regk, vcp, anc, sn, vcp_messages[idx] if vcp_messages else None)
+            )
+
+        group_hab = self.agent.hby.habByPre(gid)
+        if group_hab is None or not isinstance(group_hab, SignifyGroupHab):
+            _update_regsync_error(
+                self.agent,
+                opname,
+                424,
+                f"registry sync target group {gid} is no longer available locally",
+            )
+            return False
+
+        targets = []
+        # Late joiners may know the current multisig state but still lack the
+        # historical group event that anchored a preexisting registry VCP.
+        # Replay the group's KEL first so subsequent TEL replay can unescrow
+        # anchored registry events instead of stalling in ANC escrow.
+        self.agent.witq.query(
+            hab=self.agent.agentHab,
+            pre=gid,
+            wits=group_hab.kever.wits or None,
+        )
+        for name, regk, vcp, anc, sn, vcp_message in parsed:
+            if vcp_message is not None:
+                try:
+                    self.agent.parser.parseOne(
+                        ims=bytearray(vcp_message),
+                        tvy=self.agent.rgy.tvy,
+                        local=False,
+                    )
+                except Exception as ex:
+                    _update_regsync_error(
+                        self.agent,
+                        opname,
+                        424,
+                        f"registry sync import failed for {regk}: {ex}",
+                    )
+                    return False
+
+            if not longrunning.ensure_registry_anchor(
+                hby=self.agent.hby,
+                reger=self.agent.rgy.reger,
+                gid=gid,
+                regk=regk,
+                regd=vcp.said,
+                anchor=anc,
+            ):
+                self.agent.witq.query(
+                    hab=self.agent.agentHab,
+                    pre=gid,
+                    anchor=anc,
+                    wits=group_hab.kever.wits or None,
+                )
+
+            registry = self.agent.rgy.regs.get(regk)
+            if registry is None:
+                registry = _materialize_signify_registry(
+                    self.agent,
+                    name=name,
+                    prefix=gid,
+                    regk=regk,
+                )
+
+            if sn > 0:
+                self.agent.witq.telquery(
+                    hab=self.agent.agentHab,
+                    pre=gid,
+                    ri=regk,
+                    wits=group_hab.kever.wits or None,
+                )
+
+            targets.append(
+                dict(name=registry.name, regk=regk, regd=vcp.said, anc=anc, sn=sn)
+            )
+
+        metadata.update(
+            phase="replay",
+            phase_start=helping.nowIso8601(),
+            targets=targets,
+            error=None,
+        )
+        self.agent.monitor.update(opname, metadata=metadata)
+        return False
+
+
+class CredentialSyncRequestHandler:
+    """Machine-handled multisig credential-history sync request."""
+
+    resource = "/multisig/credential/sync"
+
+    def __init__(self, agent):
+        self.agent = agent
+
+    def handle(self, serder, attachments=None):
+        payload = serder.ked.get("a", {})
+        gid = payload.get("gid")
+        sender = serder.ked.get("i")
+        requester = payload.get("mid")
+        saids = payload.get("saids")
+        if gid is None or sender is None or requester is None or not isinstance(saids, list):
+            logger.error("invalid credential sync request payload on %s", serder.said)
+            return
+
+        hab = self.agent.hby.habByPre(gid)
+        if hab is None or not isinstance(hab, SignifyGroupHab):
+            logger.info("ignoring credential sync request for unknown group %s", gid)
+            return
+
+        members = hab.db.signingMembers(pre=gid) or []
+        if requester not in members:
+            logger.warning(
+                "ignoring credential sync request %s for non-member requester %s on %s",
+                serder.said,
+                requester,
+                gid,
+            )
+            return
+
+        if not _agent_authorized_for_member(self.agent, requester, sender):
+            logger.warning(
+                "ignoring credential sync request %s from unauthorized agent %s for %s",
+                serder.said,
+                sender,
+                requester,
+            )
+            return
+
+        if requester == hab.mhab.pre and sender == self.agent.agentHab.pre:
+            logger.info(
+                "ignoring locally originated credential sync request %s for %s",
+                serder.said,
+                gid,
+            )
+            return
+
+        for said in saids:
+            error = None
+            messages = None
+            schemas = None
+            try:
+                creder, _, _, _ = self.agent.rgy.reger.cloneCred(said=said)
+                regk = _current_credential_regk(creder)
+                registry = self.agent.rgy.regs.get(regk) if regk is not None else None
+                if registry is None or registry.hab.pre != gid:
+                    error = dict(
+                        code=424,
+                        message=(
+                            f"credential {said} is not issued from a registry controlled by {gid}"
+                        ),
+                    )
+                else:
+                    messages = _credential_sync_messages(
+                        self.agent.hby, self.agent.rgy, said
+                    )
+                    schemas = _credential_sync_schemas(
+                        self.agent.hby, self.agent.rgy, said
+                    )
+            except kering.MissingEntryError:
+                error = dict(
+                    code=424,
+                    message=f"credential {said} is not available on source {gid}",
+                )
+
+            exn, atc = _credential_sync_response_exn(
+                hab=self.agent.agentHab,
+                gid=gid,
+                said=said,
+                messages=messages,
+                schemas=schemas,
+                error=error,
+                dig=serder.said,
+            )
+            self.agent.hby.psr.parseOne(
+                ims=bytearray(exn.raw) + bytearray(atc),
+                exc=self.agent.exc,
+            )
+            self.agent.exchanges.append(
+                dict(
+                    said=exn.said,
+                    pre=self.agent.agentHab.pre,
+                    rec=[requester],
+                    topic="multisig",
+                )
+            )
+
+
+class CredentialSyncResponseHandler:
+    """Machine-handled multisig credential-history sync response."""
+
+    resource = "/multisig/credential/sync/response"
+
+    def __init__(self, agent):
+        self.agent = agent
+
+    def handle(self, serder, attachments=None):
+        self.agent.credsyncResps.append(
+            dict(serder=serder, attachments=attachments or [])
+        )
+
+
+class CredentialSyncApplyDoer(doing.Doer):
+    """Apply credential sync responses by parsing imported CESR bundles locally."""
+
+    def __init__(self, agent, responses, tock=0.0):
+        self.agent = agent
+        self.responses = responses
+        self.tock = tock
+        super(CredentialSyncApplyDoer, self).__init__(tock=tock)
+
+    def recur(self, tyme=None, tock=0.0, **opts):
+        if not self.responses:
+            return False
+
+        msg = self.responses.popleft()
+        serder = msg["serder"]
+        attachments = msg.get("attachments") or []
+        request_said = serder.ked.get("p")
+        if not request_said:
+            logger.warning("ignoring credential sync response %s without p", serder.said)
+            return False
+
+        opname, op = _find_credsync_by_request(self.agent, request_said)
+        if op is None:
+            logger.info(
+                "ignoring stale credential sync response %s for request %s",
+                serder.said,
+                request_said,
+            )
+            return False
+
+        metadata = dict(op.metadata)
+        if metadata.get("error") is not None:
+            logger.info(
+                "ignoring credential sync response %s for errored op %s",
+                serder.said,
+                opname,
+            )
+            return False
+
+        source = metadata["source"]
+        gid = metadata["pre"]
+        payload = serder.ked.get("a", {})
+        sender = serder.ked.get("i")
+        if sender is None or not _agent_authorized_for_member(self.agent, source, sender):
+            logger.info(
+                "ignoring credential sync response %s from unexpected sender %s for source %s",
+                serder.said,
+                sender,
+                source,
+            )
+            return False
+
+        if payload.get("gid") != gid:
+            logger.info(
+                "ignoring credential sync response %s with group mismatch %s for %s",
+                serder.said,
+                payload.get("gid"),
+                gid,
+            )
+            return False
+
+        said = payload.get("said")
+        if said not in metadata["saids"]:
+            logger.info(
+                "ignoring credential sync response %s for unexpected credential %s",
+                serder.said,
+                said,
+            )
+            return False
+
+        if isinstance(payload.get("error"), dict):
+            err = payload["error"]
+            _update_credsync_error(
+                self.agent,
+                opname,
+                err.get("code", 424),
+                err.get("message", f"credential sync failed for {said}"),
+                details=err.get("details"),
+            )
+            return False
+
+        if said in metadata["synced"]:
+            logger.info(
+                "ignoring duplicate credential sync response %s for %s",
+                serder.said,
+                said,
+            )
+            return False
+
+        messages = _embedded_messages_from_attachments(serder, attachments, "credmsg")
+        bundle = _embedded_stream_from_attachments(serder, attachments, "cred")
+
+        if not messages and bundle is None:
+            _update_credsync_error(
+                self.agent,
+                opname,
+                424,
+                f"credential sync response for {said} missing credential bundle",
+            )
+            return False
+
+        group_hab = self.agent.hby.habByPre(gid)
+        if group_hab is None or not isinstance(group_hab, SignifyGroupHab):
+            _update_credsync_error(
+                self.agent,
+                opname,
+                424,
+                f"credential sync target group {gid} is no longer available locally",
+            )
+            return False
+
+        try:
+            _cache_embedded_schemas(self.agent, serder, attachments)
+
+            if bundle is not None:
+                self.agent.parser.parse(
+                    ims=bytearray(bundle),
+                    tvy=self.agent.rgy.tvy,
+                    local=False,
+                )
+
+            for message in messages:
+                _query_group_anchor_for_tel_message(
+                    self.agent,
+                    gid=gid,
+                    group_hab=group_hab,
+                    message=message,
+                )
+                self.agent.parser.parseOne(
+                    ims=bytearray(message),
+                    tvy=self.agent.rgy.tvy,
+                    local=False,
+                )
+
+            # Late-join sync imports can otherwise rely on ambient doer timing to
+            # drain TEL, verifier, registrar, and dissemination escrows. Process
+            # once here so imported credential state becomes usable immediately
+            # when the local KEL/TEL data is sufficient.
+            longrunning.stabilize_credsync_state(
+                registrar=self.agent.registrar,
+                credentialer=self.agent.credentialer,
+            )
+        except Exception as ex:
+            _update_credsync_error(
+                self.agent,
+                opname,
+                424,
+                f"credential sync import failed for {said}: {ex}",
+            )
+            return False
+
+        metadata["synced"] = [*metadata["synced"], said]
+        self.agent.monitor.update(opname, metadata=metadata)
+        return False
 
 
 class RegistryResourceEnd:
@@ -1056,19 +2252,8 @@ class CredentialResourceEnd:
     def outputCred(hby, rgy, said):
         out = bytearray()
         creder, prefixer, seqner, saider = rgy.reger.cloneCred(said=said)
-        chains = creder.edge or dict()
-        saids = []
-        for key, source in chains.items():
-            if key == "d":
-                continue
-
-            if not isinstance(source, dict):
-                continue
-
-            saids.append(source["n"])
-
-        for said in saids:
-            out.extend(CredentialResourceEnd.outputCred(hby, rgy, said))
+        for chain_said in _credential_chain_saids(creder):
+            out.extend(CredentialResourceEnd.outputCred(hby, rgy, chain_said))
 
         issr = creder.issuer
         for msg in hby.db.clonePreIter(pre=issr):
@@ -1260,9 +2445,20 @@ class CredentialResourceDeleteEnd:
 
         try:
             agent.rgy.reger.cloneCreds([coring.Saider(qb64=said)], db=agent.hby.db)
-        except Exception:
-            raise falcon.HTTPNotFound(
-                description=f"credential for said {said} not found."
+        except Exception as ex:
+            raise falcon.HTTPConflict(
+                description=(
+                    f"credential history for said {said} is not available locally; "
+                    f"run credentials().sync({name!r}, saids=[{said!r}]) first"
+                )
+            ) from ex
+
+        if agent.rgy.tevers[regk].vcSn(said) is None:
+            raise falcon.HTTPConflict(
+                description=(
+                    f"credential history for said {said} is incomplete locally; "
+                    f"run credentials().sync({name!r}, saids=[{said!r}]) first"
+                )
             )
 
         if hab.kever.estOnly:

--- a/src/keria/app/grouping.py
+++ b/src/keria/app/grouping.py
@@ -11,7 +11,7 @@ from marshmallow import fields
 
 import falcon
 from typing import Optional, Union
-from keri import core
+from keri import core, kering
 from keri.app import habbing
 from keri.core import coring, eventing, serdering
 from keri.help import ogler
@@ -258,6 +258,16 @@ class MultisigJoinCollectionEnd:
             hab.make(serder=serder, sigers=sigers)
         except ValueError:
             logger.info("Already incepted group, continuing...")
+        except kering.ValidationError as ex:
+            agent.hby.deleteHab(name=name)
+            sn = serder.ked.get("s", str(serder.sn))
+            raise falcon.HTTPConflict(
+                description=(
+                    f"multisig join for group {gid} is missing prior group events "
+                    f"needed to process rotation sn={sn}; query key state/logs for "
+                    f"{gid} through sn={sn} and retry join"
+                )
+            ) from ex
 
         agent.inceptGroup(pre=gid, mpre=mhab.pre, verfers=verfers, digers=digers)
         agent.groups.append(

--- a/src/keria/app/multisig.py
+++ b/src/keria/app/multisig.py
@@ -1,0 +1,60 @@
+# -*- encoding: utf-8 -*-
+"""
+KERIA
+keria.app.multisig module
+
+Shared helpers for multisig approval flows.
+"""
+
+from keri.app.habbing import SignifyGroupHab
+from keri.core import coring
+
+
+def replay_multisig_embeds(agent, hab, *, route, embeds, labels):
+    """Replay stored non-local multisig embedded events before local approval.
+
+    Signify follower approval can happen after the matching multisig EXN was
+    already received and stored. In that local-after-remote ordering, KLI
+    explicitly replays the remote participant's signed embedded event streams
+    before it parses the follower's approval of the same proposal.
+
+    This helper restores that ordering for KERIA approval endpoints. It derives
+    the embedded-section SAID from the local approval payload, loads matching
+    non-local multisig EXNs from the mux, and replays the selected embedded
+    labels plus their pathed attachments through the parser.
+
+    The ``labels`` argument uses EXN embed-label names, not concrete KEL/TEL
+    event-type names. For example, the multisig protocol uses the embed label
+    ``anc`` for the anchoring KEL event even when the concrete event is an
+    interaction event (``ixn``).
+    """
+    if not isinstance(hab, SignifyGroupHab):
+        return 0
+
+    embed_ked = dict(embeds)
+    embed_ked["d"] = ""
+    _, embed_ked = coring.Saider.saidify(sad=embed_ked, label=coring.Saids.d)
+
+    replays = 0
+    for msg in agent.mux.get(esaid=embed_ked["d"]):
+        exn = msg["exn"]
+        if exn["r"] != route or exn["i"] == hab.mhab.pre:
+            continue
+
+        paths = msg["paths"]
+        for label in labels:
+            if label not in paths:
+                continue
+
+            sadder = coring.Sadder(ked=embeds[label])
+            attachment = paths[label]
+            if isinstance(attachment, str):
+                attachment = attachment.encode("utf-8")
+
+            ims = bytearray(sadder.raw)
+            ims.extend(attachment)
+            agent.hby.psr.parseOne(ims=ims)
+
+        replays += 1
+
+    return replays

--- a/src/keria/core/longrunning.py
+++ b/src/keria/core/longrunning.py
@@ -26,7 +26,7 @@ from keria.app import delegating
 Typeage = namedtuple(
     "Tierage",
     "oobi witness delegation group query registry credential endrole "  # type: ignore[name-match]
-    "locscheme challenge exchange submit done",
+    "locscheme challenge exchange submit regsync credsync done",
 )
 
 OpTypes = Typeage(
@@ -42,8 +42,146 @@ OpTypes = Typeage(
     challenge="challenge",
     exchange="exchange",
     submit="submit",
+    regsync="regsync",
+    credsync="credsync",
     done="done",
 )
+
+
+def ensure_registry_anchor(hby, reger, gid, regk, regd, anchor):
+    """Ensure the local registry VCP has the source-seal couple it needs.
+
+    Late joiners may learn the group KEL event that seals a registry inception
+    before any TEL replay path writes the local `reger.ancs` couple for the VCP.
+    When that happens, credential-history replay can stall waiting for the
+    registry inception anchor even though the sealing group event is already in
+    the local KEL. Reuse the known group-event seal to materialize the registry
+    anchor couple eagerly.
+    """
+
+    if regd is None or anchor is None:
+        return False
+
+    dgkey = dbing.dgKey(regk, regd)
+    if reger.getAnc(dgkey) is not None:
+        return True
+
+    serder = hby.db.fetchLastSealingEventByEventSeal(pre=gid, seal=anchor)
+    if serder is None:
+        return False
+
+    seqner = coring.Seqner(sn=serder.sn)
+    saider = coring.Saider(qb64=serder.said)
+    reger.putAnc(dgkey, seqner.qb64b + saider.qb64b)
+    return True
+
+
+def ensure_tel_anchor(hby, reger, gid, pre, said, anchor):
+    """Ensure the local TEL event has the source-seal couple it needs.
+
+    Late joiners may have already learned the group KEL event that seals a
+    synced credential TEL event while still missing the local `reger.ancs`
+    couple for that TEL event. When that happens, replay can stall in
+    anchorless escrow even though the sealing group event is already present
+    locally.
+    """
+
+    if pre is None or said is None or anchor is None:
+        return False
+
+    dgkey = dbing.dgKey(pre, said)
+    if reger.getAnc(dgkey) is not None:
+        return True
+
+    serder = hby.db.fetchLastSealingEventByEventSeal(pre=gid, seal=anchor)
+    if serder is None:
+        return False
+
+    seqner = coring.Seqner(sn=serder.sn)
+    saider = coring.Saider(qb64=serder.said)
+    reger.putAnc(dgkey, seqner.qb64b + saider.qb64b)
+    return True
+
+
+def stabilize_credsync_state(registrar=None, credentialer=None):
+    """Drive the local escrows needed for imported credential history to settle.
+
+    Late-join credential sync can import the raw CESR material before the local
+    TEL, verifier, registrar, and credential dissemination escrows have all had
+    a chance to observe the newly available state. Running one explicit
+    stabilization pass keeps `/operations/credsync.*` from timing out on state
+    that is already locally derivable.
+    """
+
+    rgy = registrar.rgy if registrar is not None else None
+    if rgy is not None:
+        rgy.processEscrows()
+
+    verifier = None
+    if credentialer is not None:
+        verifier = getattr(credentialer, "verifier", None)
+    if verifier is None and registrar is not None:
+        verifier = getattr(registrar, "verifier", None)
+    if verifier is not None:
+        verifier.processEscrows()
+
+    if registrar is not None:
+        registrar.processEscrows()
+
+    if credentialer is not None:
+        credentialer.processEscrows()
+
+
+def credsync_statuses(rgy, saids):
+    """Summarize per-credential readiness for late-join history replay."""
+
+    statuses = []
+    for said in saids:
+        status = dict(said=said)
+
+        if rgy.reger.saved.get(keys=(said,)) is None:
+            status["state"] = "missing_saved"
+            statuses.append(status)
+            continue
+
+        try:
+            creder, _, _, _ = rgy.reger.cloneCred(said=said)
+        except kering.MissingEntryError:
+            status["state"] = "missing_clone"
+            statuses.append(status)
+            continue
+
+        regk = creder.regi if getattr(creder, "regi", None) is not None else creder.sad.get("ri")
+        if regk is None:
+            status["state"] = "missing_registry_reference"
+            statuses.append(status)
+            continue
+
+        status["regk"] = regk
+        if regk not in rgy.regs or regk not in rgy.tevers:
+            status["state"] = "missing_registry_state"
+            statuses.append(status)
+            continue
+
+        try:
+            vcstate = rgy.tevers[regk].vcState(said)
+        except Exception as ex:
+            status["state"] = "vc_state_error"
+            status["error"] = str(ex)
+            statuses.append(status)
+            continue
+
+        if vcstate is None:
+            status["state"] = "missing_vc_state"
+            statuses.append(status)
+            continue
+
+        status["state"] = "ready"
+        status["sn"] = getattr(vcstate, "sn", getattr(vcstate, "s", None))
+        status["et"] = getattr(vcstate, "et", getattr(vcstate, "eilk", None))
+        statuses.append(status)
+
+    return statuses
 
 
 @dataclass_json
@@ -194,6 +332,15 @@ class Monitor:
 
         # Return Operation with full status check in case its already finished.
         return self.get(name)
+
+    def update(self, name, metadata):
+        """Update metadata for an existing long running operation."""
+        if (op := self.opr.ops.get(keys=(name,))) is None:
+            raise kering.ValidationError(f"long running operation '{name}' not found")
+
+        updated = Op(oid=op.oid, type=op.type, start=op.start, metadata=metadata)
+        self.opr.ops.pin(keys=(name,), val=updated)
+        return updated
 
     def get(self, name):
         if (op := self.opr.ops.get(keys=(name,))) is None:
@@ -564,6 +711,187 @@ class Monitor:
                     )
                 else:
                     done = False
+
+        elif op.type in (OpTypes.regsync,):
+            required = ("pre", "source", "phase", "phase_start", "request", "targets")
+            missing = [field for field in required if field not in op.metadata]
+            if missing:
+                raise kering.ValidationError(
+                    f"invalid long running {op.type} operation, metadata missing required fields {tuple(missing)}"
+                )
+
+            if "error" in op.metadata and op.metadata["error"] is not None:
+                err = op.metadata["error"]
+                done = True
+                error = OperationStatus(
+                    code=err["code"],
+                    message=err["message"],
+                    details=err.get("details"),
+                )
+            else:
+                phase = op.metadata["phase"]
+                phase_start = helping.fromIso8601(op.metadata["phase_start"])
+                dtnow = helping.nowUTC()
+
+                if phase == "catalog":
+                    if (dtnow - phase_start) > datetime.timedelta(seconds=10):
+                        done = True
+                        error = OperationStatus(
+                            code=504,
+                            message=(
+                                f"long running {op.type} for {op.oid} timed out waiting "
+                                f"for registry catalog response from {op.metadata['source']}"
+                            ),
+                            details=dict(phase=phase, source=op.metadata["source"]),
+                        )
+                    else:
+                        done = False
+
+                elif phase == "replay":
+                    rgy = self.registrar.rgy if self.registrar is not None else None
+                    if rgy is None:
+                        raise kering.ValidationError(
+                            f"invalid long running {op.type} operation, registrar not configured"
+                        )
+
+                    pending = False
+                    for target in op.metadata["targets"]:
+                        regk = target["regk"]
+                        regd = target.get("regd")
+                        target_sn = int(target["sn"])
+                        if regk not in rgy.regs or regk not in rgy.tevers:
+                            pending = True
+                            break
+
+                        if rgy.tevers[regk].sn < target_sn:
+                            pending = True
+                            break
+
+                        anchor = target.get("anc")
+                        if anchor is not None and regd is not None:
+                            if not ensure_registry_anchor(
+                                hby=self.hby,
+                                reger=rgy.reger,
+                                gid=op.metadata["pre"],
+                                regk=regk,
+                                regd=regd,
+                                anchor=anchor,
+                            ):
+                                pending = True
+                                break
+
+                        if regd is not None and rgy.reger.getAnc(dbing.dgKey(regk, regd)) is None:
+                            pending = True
+                            break
+
+                    if pending:
+                        if (dtnow - phase_start) > datetime.timedelta(seconds=30):
+                            done = True
+                            error = OperationStatus(
+                                code=504,
+                                message=(
+                                    f"long running {op.type} for {op.oid} timed out waiting "
+                                    f"for registry TEL replay"
+                                ),
+                                details=dict(
+                                    phase=phase,
+                                    source=op.metadata["source"],
+                                    targets=op.metadata["targets"],
+                                ),
+                            )
+                        else:
+                            done = False
+                    else:
+                        done = True
+                        response = dict(
+                            pre=op.metadata["pre"],
+                            source=op.metadata["source"],
+                            synced=[
+                                dict(
+                                    name=target["name"],
+                                    regk=target["regk"],
+                                    sn=target["sn"],
+                                )
+                                for target in op.metadata["targets"]
+                            ],
+                        )
+                else:
+                    raise kering.ValidationError(
+                        f"invalid long running {op.type} operation, unknown phase '{phase}'"
+                    )
+
+        elif op.type in (OpTypes.credsync,):
+            required = (
+                "pre",
+                "source",
+                "phase",
+                "phase_start",
+                "request",
+                "saids",
+                "synced",
+            )
+            missing = [field for field in required if field not in op.metadata]
+            if missing:
+                raise kering.ValidationError(
+                    f"invalid long running {op.type} operation, metadata missing required fields {tuple(missing)}"
+                )
+
+            if "error" in op.metadata and op.metadata["error"] is not None:
+                err = op.metadata["error"]
+                done = True
+                error = OperationStatus(
+                    code=err["code"],
+                    message=err["message"],
+                    details=err.get("details"),
+                )
+            else:
+                phase = op.metadata["phase"]
+                if phase != "replay":
+                    raise kering.ValidationError(
+                        f"invalid long running {op.type} operation, unknown phase '{phase}'"
+                    )
+
+                if self.registrar is None:
+                    raise kering.ValidationError(
+                        f"invalid long running {op.type} operation, registrar not configured"
+                    )
+
+                phase_start = helping.fromIso8601(op.metadata["phase_start"])
+                dtnow = helping.nowUTC()
+                rgy = self.registrar.rgy
+                stabilize_credsync_state(
+                    registrar=self.registrar,
+                    credentialer=self.credentialer,
+                )
+                statuses = credsync_statuses(rgy=rgy, saids=op.metadata["saids"])
+                pending = any(status["state"] != "ready" for status in statuses)
+
+                if pending:
+                    if (dtnow - phase_start) > datetime.timedelta(seconds=30):
+                        done = True
+                        error = OperationStatus(
+                            code=504,
+                            message=(
+                                f"long running {op.type} for {op.oid} timed out waiting "
+                                f"for credential history replay"
+                            ),
+                            details=dict(
+                                phase=phase,
+                                source=op.metadata["source"],
+                                saids=op.metadata["saids"],
+                                synced=op.metadata["synced"],
+                                statuses=statuses,
+                            ),
+                        )
+                    else:
+                        done = False
+                else:
+                    done = True
+                    response = dict(
+                        pre=op.metadata["pre"],
+                        source=op.metadata["source"],
+                        synced=op.metadata["saids"],
+                    )
 
         elif op.type in (OpTypes.done,):
             done = True

--- a/tests/app/test_aiding.py
+++ b/tests/app/test_aiding.py
@@ -152,6 +152,61 @@ def test_endrole_ends(helpers):
         }
 
 
+def test_endrole_replays_multisig_embeds_before_local_reply_processing(
+    helpers, monkeypatch
+):
+    """Follower B must replay A's stored `/multisig/rpy` before endorsing.
+
+    This is an endpoint-order test, not a full multisig integration test.
+
+    Identity mapping:
+
+    - participant A is represented by the mocked `replay_multisig_embeds(...)`
+      call, which stands in for the already-stored remote `/multisig/rpy`.
+    - participant B is the local `user1` habitat handled by this KERIA agent.
+    - `rpy` is B's local approval payload for the same end-role authorization.
+
+    The important assertion is ordering: KERIA must replay A's stored reply
+    stream before B processes B's own local reply.
+    """
+    with helpers.openKeria() as (agency, agent, app, client):
+        end = aiding.IdentifierCollectionEnd()
+        app.add_route("/identifiers", end)
+        idResEnd = aiding.IdentifierResourceEnd()
+        app.add_route("/identifiers/{name}", idResEnd)
+        endRolesEnd = aiding.EndRoleCollectionEnd()
+        app.add_route("/identifiers/{name}/endroles", endRolesEnd)
+
+        # Participant B's local AID and the reply payload B later submits to
+        # KERIA when B approves the multisig end-role proposal.
+        salt = b"0123456789abcdef"
+        op = helpers.createAid(client, "user1", salt)
+        aid = op["response"]
+        rpy = helpers.endrole(aid["i"], agent.agentHab.pre)
+        sigs = helpers.sign(salt, 0, 0, rpy.raw)
+
+        calls = []
+
+        # This stands in for participant A's earlier `/multisig/rpy` arrival.
+        # We only care that the follower approval path invokes replay first.
+        def fake_replay(*args, **kwargs):
+            calls.append(("replay", kwargs["route"], kwargs["labels"]))
+
+        def fake_process_reply(*args, **kwargs):
+            calls.append("processReply")
+
+        monkeypatch.setattr(aiding, "replay_multisig_embeds", fake_replay)
+        monkeypatch.setattr(agent.hby.rvy, "processReply", fake_process_reply)
+
+        res = client.simulate_post(
+            path="/identifiers/user1/endroles",
+            body=json.dumps(dict(rpy=rpy.ked, sigs=sigs)).encode("utf-8"),
+        )
+
+        assert res.status_code == 202
+        assert calls[:2] == [("replay", "/multisig/rpy", ("rpy",)), "processReply"]
+
+
 def test_locscheme_ends(helpers, mockHelpingNowUTC):
     with helpers.openKeria() as (agency, agent, app, client):
         locSchemesEnd = aiding.LocSchemeCollectionEnd()

--- a/tests/app/test_credentialing.py
+++ b/tests/app/test_credentialing.py
@@ -7,6 +7,7 @@ Testing credentialing endpoint in the Mark II Agent
 """
 
 import json
+from types import SimpleNamespace
 
 import falcon
 from falcon import testing
@@ -862,3 +863,108 @@ def test_revoke_credential(helpers, seeder):
         assert res.status_code == 200
         assert res.json["s"] == "1"
         assert res.json["et"] == "rev"
+
+def test_replay_multisig_embeds_restores_local_after_remote_follower_approval(
+    helpers, monkeypatch
+):
+    """A stored remote `/multisig/vcp` must replay the leader's `anc` stream.
+
+    This test is intentionally narrow. It does not try to create a full
+    multisig registry. It proves only the missing follower behavior:
+
+    1. a remote `/multisig/vcp` proposal already exists in mux storage,
+    2. the follower later approves the same proposal through the credentialing
+       path,
+    3. `replay_multisig_embeds(...)` must parse the stored remote `anc` event
+       stream (`ixn` raw bytes plus `paths["anc"]`) before local approval
+       continues.
+
+    That local-after-remote ordering is the case `Multiplexor.add(...)` does
+    not repair by itself.
+    """
+
+    class FakeSignifyGroupHab:
+        pass
+
+    monkeypatch.setattr(credentialing, "SignifyGroupHab", FakeSignifyGroupHab)
+
+    with helpers.openKeria() as (agency, agent, app, client):
+        end = aiding.IdentifierCollectionEnd()
+        app.add_route("/identifiers", end)
+
+        # Build a realistic registry proposal payload using a real AID and a
+        # real anchoring interaction event. This keeps the test concrete while
+        # avoiding a full live multisig stack.
+        salt = b"0123456789abcdef"
+        op = helpers.createAid(client, "test", salt)
+        aid = op["response"]
+        pre = aid["i"]
+
+        nonce = Salter().qb64
+        regser = eventing.incept(
+            pre,
+            baks=[],
+            toad="0",
+            nonce=nonce,
+            cnfg=[TraitCodex.NoBackers],
+            code=coring.MtrDex.Blake3_256,
+        )
+        anchor = dict(i=regser.ked["i"], s=regser.ked["s"], d=regser.said)
+        ixn, _ = helpers.interact(
+            pre=pre, bran=salt, pidx=0, ridx=0, dig=aid["d"], sn="1", data=[anchor]
+        )
+
+        # This is the same approval payload shape the follower later submits to
+        # `POST /identifiers/{name}/registries`: a VCP plus the anchoring event
+        # carried under the EXN protocol label `anc`.
+        follower_approval_payload = dict(vcp=regser.ked, anc=ixn.ked)
+
+        # `replay_multisig_embeds(...)` derives the embedded-section SAID from
+        # that approval payload, then asks mux for stored EXNs for the same
+        # logical proposal.
+        embed_ked = dict(follower_approval_payload)
+        embed_ked["d"] = ""
+        _, embed_ked = coring.Saider.saidify(sad=embed_ked, label=coring.Saids.d)
+        proposal_esaid = embed_ked["d"]
+
+        parsed_message_streams = []
+
+        class RecordingParser:
+            def parseOne(self, ims):
+                parsed_message_streams.append(bytes(ims))
+
+        class StoredRemoteProposalMux:
+            def get(self, esaid):
+                assert esaid == proposal_esaid
+                return [
+                    dict(
+                        exn={"r": "/multisig/vcp", "i": "remote-member-pre"},
+                        paths={"anc": "FAKE-REMOTE-ANC-ATC"},
+                    )
+                ]
+
+        # Simulate the follower-side KERIA view:
+        # - mux already has a stored remote `/multisig/vcp`
+        # - the parser will record exactly what the helper replays
+        fake_agent = SimpleNamespace(
+            mux=StoredRemoteProposalMux(),
+            hby=SimpleNamespace(psr=RecordingParser()),
+        )
+        hab = FakeSignifyGroupHab()
+        hab.mhab = SimpleNamespace(pre="local-member-pre")
+
+        replays = credentialing.replay_multisig_embeds(
+            fake_agent,
+            hab,
+            route="/multisig/vcp",
+            embeds=follower_approval_payload,
+            labels=("anc",),
+        )
+
+        # The replayed byte stream must be the leader's anchoring event stream:
+        # the `ixn` raw bytes followed by the stored remote attachment group.
+        expected_remote_anc_stream = bytearray(serdering.SerderKERI(sad=ixn.ked).raw)
+        expected_remote_anc_stream.extend(b"FAKE-REMOTE-ANC-ATC")
+
+        assert replays == 1
+        assert parsed_message_streams == [bytes(expected_remote_anc_stream)]

--- a/tests/app/test_credentialing.py
+++ b/tests/app/test_credentialing.py
@@ -15,6 +15,7 @@ from hio.base import doing
 from keri.app import habbing
 from keri.core import scheming, coring, parsing, serdering
 from keri.core.eventing import SealEvent
+from keri.db import dbing
 from keri.core.signing import Salter
 from keri.kering import TraitCodex
 from keri.vc import proving
@@ -39,6 +40,10 @@ def test_load_ends(helpers):
         assert isinstance(end, credentialing.SchemaResourceEnd)
         (end, *_) = app._router.find("/identifiers/NAME/registries")
         assert isinstance(end, credentialing.RegistryCollectionEnd)
+        (end, *_) = app._router.find("/identifiers/NAME/registries/sync")
+        assert isinstance(end, credentialing.RegistrySyncCollectionEnd)
+        (end, *_) = app._router.find("/identifiers/NAME/credentials/sync")
+        assert isinstance(end, credentialing.CredentialSyncCollectionEnd)
 
 
 def test_schema_ends(helpers):
@@ -290,6 +295,90 @@ def test_registry_end(helpers, seeder):
         result = client.simulate_delete(path="/operations/bad_name")
         assert result.status == falcon.HTTP_404
         assert result.json == {"title": "long running operation 'bad_name' not found"}
+
+
+def test_registry_sync_end(helpers):
+    with helpers.openKeria() as (agency, agent, app, client):
+        sync_end = credentialing.RegistrySyncCollectionEnd()
+        app.add_route("/identifiers/{name}/registries/sync", sync_end)
+        end = aiding.IdentifierCollectionEnd()
+        app.add_route("/identifiers", end)
+
+        salt = b"0123456789abcdef"
+        helpers.createAid(client, "test", salt)
+
+        result = client.simulate_post(
+            path="/identifiers/bad/registries/sync",
+            body=b"{}",
+        )
+        assert result.status == falcon.HTTP_404
+        assert result.json == {
+            "description": "bad is not a valid reference to an identifier",
+            "title": "404 Not Found",
+        }
+
+        result = client.simulate_post(
+            path="/identifiers/test/registries/sync",
+            body=b"{}",
+        )
+        assert result.status == falcon.HTTP_409
+        assert result.json == {
+            "description": "hab for alias or prefix test is not a multisig",
+            "title": "409 Conflict",
+        }
+
+
+def test_credential_sync_end(helpers, monkeypatch):
+    with helpers.openKeria() as (agency, agent, app, client):
+        sync_end = credentialing.CredentialSyncCollectionEnd()
+        app.add_route("/identifiers/{name}/credentials/sync", sync_end)
+        end = aiding.IdentifierCollectionEnd()
+        app.add_route("/identifiers", end)
+
+        salt = b"0123456789abcdef"
+        helpers.createAid(client, "test", salt)
+
+        result = client.simulate_post(
+            path="/identifiers/bad/credentials/sync",
+            body=b'{"saids":["Ecred123"]}',
+        )
+        assert result.status == falcon.HTTP_404
+        assert result.json == {
+            "description": "bad is not a valid reference to an identifier",
+            "title": "404 Not Found",
+        }
+
+        result = client.simulate_post(
+            path="/identifiers/test/credentials/sync",
+            body=b'{"saids":["Ecred123"]}',
+        )
+        assert result.status == falcon.HTTP_409
+        assert result.json == {
+            "description": "hab for alias or prefix test is not a multisig",
+            "title": "409 Conflict",
+        }
+
+        fake_group = SimpleNamespace(
+            pre="EGroup0000000000000000000000000000000000000000",
+            mhab=SimpleNamespace(pre="Emember0000000000000000000000000000000000000"),
+        )
+        monkeypatch.setattr(
+            credentialing, "_resolve_group_identifier", lambda agent, name: fake_group
+        )
+        monkeypatch.setattr(
+            credentialing,
+            "_select_regsync_source",
+            lambda agent, hab, source=None: "Esource0000000000000000000000000000000000000",
+        )
+        result = client.simulate_post(
+            path="/identifiers/test/credentials/sync",
+            body=b'{"saids":[]}',
+        )
+        assert result.status == falcon.HTTP_400
+        assert result.json == {
+            "description": "'saids' is required and must be a non-empty list",
+            "title": "400 Bad Request",
+        }
 
 
 def test_issue_credential(helpers, seeder):
@@ -810,10 +899,13 @@ def test_revoke_credential(helpers, seeder):
                 path=f"/identifiers/issuer/credentials/{regser.said}",
                 body=json.dumps(body).encode("utf-8"),
             )
-            assert res.status_code == 404
+            assert res.status_code == 409
             assert res.json == {
-                "description": f"credential for said {regser.said} not found.",
-                "title": "404 Not Found",
+                "description": (
+                    f"credential history for said {regser.said} is not available locally; "
+                    f"run credentials().sync('issuer', saids=['{regser.said}']) first"
+                ),
+                "title": "409 Conflict",
             }
 
             badrev = regser.ked.copy()
@@ -1063,6 +1155,7 @@ def test_revoke_credential_replays_multisig_embeds_before_local_approval(
             monkeypatch.setattr(
                 agent.rgy.reger, "cloneCreds", lambda *args, **kwargs: []
             )
+            monkeypatch.setattr(agent.rgy.tevers[registry["regk"]], "vcSn", lambda said: 0)
             monkeypatch.setattr(
                 agent.registrar,
                 "revoke",
@@ -1079,6 +1172,323 @@ def test_revoke_credential_replays_multisig_embeds_before_local_approval(
             assert calls[:2] == [("replay", "/multisig/rev", ("anc",)), "interact"]
         finally:
             doist.exit(deeds=agent_deeds)
+
+
+def test_revoke_credential_sync_conflict_has_no_local_side_effects(
+    helpers, monkeypatch
+):
+    """The sync-first revoke conflict must fail before any local TEL mutation.
+
+    This is the negative twin of the replay-order test above. When the local
+    late joiner does not yet have usable credential history, KERIA should
+    return the explicit `409 credentials().sync(...) first` conflict before it
+    replays peer embeds, before it approves the local interaction, and before
+    it writes any revocation TEL material locally.
+    """
+    with helpers.openKeria() as (agency, agent, app, client):
+        idResEnd = aiding.IdentifierResourceEnd()
+        app.add_route("/identifiers/{name}", idResEnd)
+        registryEnd = credentialing.RegistryCollectionEnd(idResEnd)
+        app.add_route("/identifiers/{name}/registries", registryEnd)
+        credResDelEnd = credentialing.CredentialResourceDeleteEnd(idResEnd)
+        app.add_route("/identifiers/{name}/credentials/{said}", credResDelEnd)
+        end = aiding.IdentifierCollectionEnd()
+        app.add_route("/identifiers", end)
+
+        doist = doing.Doist(limit=1.0, tock=0.03125, real=True)
+        agent_deeds = doist.enter(doers=[agent])
+        try:
+            isalt = b"0123456789abcdef"
+            registry, follower_b_issuer = helpers.createRegistry(
+                client, agent, isalt, doist, agent_deeds
+            )
+
+            dt = "2021-01-01T00:00:00.000000+00:00"
+            creder = proving.credential(
+                issuer=follower_b_issuer["prefix"],
+                schema="EFgnk_c08WmZGgv9_mpldibRuqFMTQN-rAgtD-TCOwbs",
+                recipient=follower_b_issuer["prefix"],
+                data=dict(LEI="254900DA0GOGCFVWB618", dt=dt),
+                source={},
+                status=registry["regk"],
+            )
+            iserder = eventing.issue(vcdig=creder.said, regk=registry["regk"], dt=dt)
+            rserder = eventing.revoke(
+                vcdig=creder.said, regk=registry["regk"], dig=iserder.said, dt=dt
+            )
+            anchor = dict(i=rserder.ked["i"], s=rserder.ked["s"], d=rserder.said)
+            anc, _ = helpers.interact(
+                pre=follower_b_issuer["prefix"],
+                bran=isalt,
+                pidx=0,
+                ridx=0,
+                dig=follower_b_issuer["state"]["d"],
+                sn="2",
+                data=[anchor],
+            )
+
+            calls = []
+            before_tel = list(agent.rgy.reger.clonePreIter(pre=creder.said))
+            revoke_anchor_key = dbing.dgKey(registry["regk"], rserder.said)
+            assert agent.rgy.reger.getAnc(revoke_anchor_key) is None
+
+            def fake_replay(*args, **kwargs):
+                calls.append(("replay", kwargs["route"], kwargs["labels"]))
+
+            def fake_interact(*args, **kwargs):
+                calls.append("interact")
+                raise AssertionError("local interact should not run before sync-first 409")
+
+            def fake_revoke(*args, **kwargs):
+                calls.append("registrar.revoke")
+                raise AssertionError("registrar.revoke should not run before sync-first 409")
+
+            monkeypatch.setattr(credentialing, "replay_multisig_embeds", fake_replay)
+            monkeypatch.setattr(idResEnd, "interact", fake_interact)
+            monkeypatch.setattr(agent.registrar, "revoke", fake_revoke)
+            monkeypatch.setattr(
+                agent.rgy.reger, "cloneCreds", lambda *args, **kwargs: [creder]
+            )
+            monkeypatch.setattr(agent.rgy.tevers[registry["regk"]], "vcSn", lambda said: None)
+
+            body = dict(rev=rserder.ked, ixn=anc.ked)
+            res = client.simulate_delete(
+                path=f"/identifiers/issuer/credentials/{creder.said}",
+                body=json.dumps(body).encode("utf-8"),
+            )
+
+            assert res.status_code == 409
+            assert res.json == {
+                "description": (
+                    f"credential history for said {creder.said} is incomplete locally; "
+                    f"run credentials().sync('issuer', saids=['{creder.said}']) first"
+                ),
+                "title": "409 Conflict",
+            }
+            assert calls == []
+            assert agent.rgy.tevers[registry["regk"]].vcSn(creder.said) is None
+            assert list(agent.rgy.reger.clonePreIter(pre=creder.said)) == before_tel
+            assert agent.rgy.reger.getAnc(revoke_anchor_key) is None
+        finally:
+            doist.exit(deeds=agent_deeds)
+
+
+def test_query_group_anchor_for_tel_message_backfills_local_tel_anchor(
+    helpers, monkeypatch
+):
+    with helpers.openKeria() as (agency, agent, app, client):
+        source_serder = agent.agentHab.kever.serder
+        rserder = eventing.revoke(
+            vcdig=source_serder.said,
+            regk=source_serder.said,
+            dig=source_serder.said,
+            dt="2023-09-27T16:27:14.376928+00:00",
+        )
+        queried = []
+        group_hab = SimpleNamespace(kever=SimpleNamespace(wits=["BWitnessAid"]))
+
+        monkeypatch.setattr(
+            agent.hby.db,
+            "fetchLastSealingEventByEventSeal",
+            lambda pre, seal: source_serder,
+        )
+        monkeypatch.setattr(
+            agent.witq,
+            "query",
+            lambda **kwargs: queried.append(kwargs),
+        )
+
+        credentialing._query_group_anchor_for_tel_message(
+            agent,
+            gid=agent.agentHab.pre,
+            group_hab=group_hab,
+            message=rserder.raw,
+        )
+
+        assert queried == []
+        assert (
+            agent.rgy.reger.getAnc(dbing.dgKey(rserder.pre, rserder.said))
+            == coring.Seqner(sn=source_serder.sn).qb64b
+            + coring.Saider(qb64=source_serder.said).qb64b
+        )
+
+
+def test_query_group_anchor_for_tel_message_queries_when_anchor_event_missing(
+    helpers, monkeypatch
+):
+    with helpers.openKeria() as (agency, agent, app, client):
+        source_serder = agent.agentHab.kever.serder
+        rserder = eventing.revoke(
+            vcdig=source_serder.said,
+            regk=source_serder.said,
+            dig=source_serder.said,
+            dt="2023-09-27T16:27:14.376928+00:00",
+        )
+        queried = []
+        group_hab = SimpleNamespace(kever=SimpleNamespace(wits=["BWitnessAid"]))
+
+        monkeypatch.setattr(
+            agent.hby.db,
+            "fetchLastSealingEventByEventSeal",
+            lambda pre, seal: None,
+        )
+        monkeypatch.setattr(
+            agent.witq,
+            "query",
+            lambda **kwargs: queried.append(kwargs),
+        )
+
+        credentialing._query_group_anchor_for_tel_message(
+            agent,
+            gid=agent.agentHab.pre,
+            group_hab=group_hab,
+            message=rserder.raw,
+        )
+
+        assert agent.rgy.reger.getAnc(dbing.dgKey(rserder.pre, rserder.said)) is None
+        assert queried == [
+            {
+                "hab": agent.agentHab,
+                "pre": agent.agentHab.pre,
+                "anchor": dict(i=rserder.pre, s=rserder.snh, d=rserder.said),
+                "wits": ["BWitnessAid"],
+            }
+        ]
+
+
+def test_credential_sync_schemas_exports_cached_schema(helpers, monkeypatch):
+    with helpers.openKeria() as (agency, agent, app, client):
+        schemer = scheming.Schemer(
+            sed={
+                "$id": "",
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {"LEI": {"type": "string"}},
+            },
+            typ=scheming.JSONSchema(),
+            code=coring.MtrDex.Blake3_256,
+        )
+        agent.hby.db.schema.pin(schemer.said, schemer)
+        creder = SimpleNamespace(schema=schemer.said, edge=None)
+
+        monkeypatch.setattr(
+            agent.rgy.reger,
+            "cloneCred",
+            lambda said: (creder, None, None, None),
+        )
+
+        assert credentialing._credential_sync_schemas(agent.hby, agent.rgy, "ECredential") == [
+            schemer.sed
+        ]
+
+
+def test_cache_embedded_schemas_adds_schema_to_resolver(helpers):
+    with helpers.openKeria() as (agency, agent, app, client):
+        schemer = scheming.Schemer(
+            sed={
+                "$id": "",
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {"LEI": {"type": "string"}},
+            },
+            typ=scheming.JSONSchema(),
+            code=coring.MtrDex.Blake3_256,
+        )
+        exn, _ = credentialing._credential_sync_response_exn(
+            hab=agent.agentHab,
+            gid=agent.agentHab.pre,
+            said="ECredentialSaid",
+            dig="ERequestSaid",
+            schemas=[schemer.sed],
+        )
+
+        assert agent.verifier.resolver.resolve(schemer.said) is None
+
+        cached = credentialing._cache_embedded_schemas(agent, exn, [])
+
+        assert cached == [schemer.sed]
+        assert agent.verifier.resolver.resolve(schemer.said) == schemer.raw
+
+
+def test_registry_sync_request_handler_ignores_locally_originated_request(monkeypatch):
+    class FakeGroupHab:
+        def __init__(self):
+            self.pre = "EHFakeGroup"
+            self.mhab = SimpleNamespace(pre="ELocalMember")
+            self.db = SimpleNamespace(
+                signingMembers=lambda pre: ["ELocalMember", "ERemoteMember"]
+            )
+
+    group_hab = FakeGroupHab()
+    parsed = []
+    agent = SimpleNamespace(
+        hby=SimpleNamespace(habByPre=lambda pre: group_hab, psr=SimpleNamespace(parseOne=lambda **kwa: parsed.append(kwa))),
+        agentHab=SimpleNamespace(pre="ELocalAgent"),
+        rgy=SimpleNamespace(regs={}),
+        exchanges=[],
+        exc=object(),
+    )
+    handler = credentialing.RegistrySyncRequestHandler(agent=agent)
+    serder = SimpleNamespace(
+        said="ERegistrySyncRequest",
+        ked={"a": {"gid": group_hab.pre, "mid": group_hab.mhab.pre}, "i": agent.agentHab.pre},
+    )
+
+    monkeypatch.setattr(credentialing, "SignifyGroupHab", FakeGroupHab)
+    monkeypatch.setattr(
+        credentialing,
+        "_agent_authorized_for_member",
+        lambda agent, member, eid: True,
+    )
+
+    handler.handle(serder)
+
+    assert parsed == []
+    assert agent.exchanges == []
+
+
+def test_credential_sync_request_handler_ignores_locally_originated_request(monkeypatch):
+    class FakeGroupHab:
+        def __init__(self):
+            self.pre = "EHFakeGroup"
+            self.mhab = SimpleNamespace(pre="ELocalMember")
+            self.db = SimpleNamespace(
+                signingMembers=lambda pre: ["ELocalMember", "ERemoteMember"]
+            )
+
+    group_hab = FakeGroupHab()
+    parsed = []
+    agent = SimpleNamespace(
+        hby=SimpleNamespace(habByPre=lambda pre: group_hab, psr=SimpleNamespace(parseOne=lambda **kwa: parsed.append(kwa))),
+        agentHab=SimpleNamespace(pre="ELocalAgent"),
+        rgy=SimpleNamespace(reger=SimpleNamespace(cloneCred=lambda said: (_ for _ in ()).throw(AssertionError("should not clone local credential history")))),
+        exchanges=[],
+        exc=object(),
+    )
+    handler = credentialing.CredentialSyncRequestHandler(agent=agent)
+    serder = SimpleNamespace(
+        said="ECredentialSyncRequest",
+        ked={
+            "a": {
+                "gid": group_hab.pre,
+                "mid": group_hab.mhab.pre,
+                "saids": ["ECredentialSaid"],
+            },
+            "i": agent.agentHab.pre,
+        },
+    )
+
+    monkeypatch.setattr(credentialing, "SignifyGroupHab", FakeGroupHab)
+    monkeypatch.setattr(
+        credentialing,
+        "_agent_authorized_for_member",
+        lambda agent, member, eid: True,
+    )
+
+    handler.handle(serder)
+
+    assert parsed == []
+    assert agent.exchanges == []
 
 
 def test_keria_registrar_issue_starts_counselor_for_multisig_hab(monkeypatch):

--- a/tests/app/test_credentialing.py
+++ b/tests/app/test_credentialing.py
@@ -313,120 +313,124 @@ def test_issue_credential(helpers, seeder):
         seeder.seedSchema(agent.hby.db)
         seeder.seedSchema(agent1.hby.db)
 
-        # create the server that will receive the credential issuance messages
-        serverDoer = helpers.server(agency)
-
         tock = 0.03125
         limit = 1.0
         doist = doing.Doist(limit=limit, tock=tock, real=True)
-        deeds = doist.enter(doers=[agent, serverDoer])
+        agent_deeds = doist.enter(doers=[agent])
+        verify_deeds = None
+        try:
+            isalt = b"0123456789abcdef"
+            registry, issuer = helpers.createRegistry(
+                client, agent, isalt, doist, agent_deeds
+            )
 
-        isalt = b"0123456789abcdef"
-        registry, issuer = helpers.createRegistry(client, agent, isalt, doist, deeds)
+            iaid = issuer["prefix"]
+            idig = issuer["state"]["d"]
 
-        iaid = issuer["prefix"]
-        idig = issuer["state"]["d"]
+            rsalt = b"abcdef0123456789"
+            op = helpers.createAid(client, "recipient", rsalt)
+            aid = op["response"]
+            recp = aid["i"]
+            assert recp == "EMgdjM1qALk3jlh4P2YyLRSTcjSOjLXD3e_uYpxbdbg6"
 
-        rsalt = b"abcdef0123456789"
-        op = helpers.createAid(client, "recipient", rsalt)
-        aid = op["response"]
-        recp = aid["i"]
-        assert recp == "EMgdjM1qALk3jlh4P2YyLRSTcjSOjLXD3e_uYpxbdbg6"
+            helpers.createEndRole(client, agent, recp, "recipient", rsalt)
 
-        helpers.createEndRole(client, agent, recp, "recipient", rsalt)
+            dt = "2021-01-01T00:00:00.000000+00:00"
+            schema = "EFgnk_c08WmZGgv9_mpldibRuqFMTQN-rAgtD-TCOwbs"
+            data = dict(LEI="254900DA0GOGCFVWB618", dt=dt)
+            creder = proving.credential(
+                issuer=iaid,
+                schema=schema,
+                recipient=recp,
+                data=data,
+                source={},
+                status=registry["regk"],
+            )
 
-        dt = "2021-01-01T00:00:00.000000+00:00"
-        schema = "EFgnk_c08WmZGgv9_mpldibRuqFMTQN-rAgtD-TCOwbs"
-        data = dict(LEI="254900DA0GOGCFVWB618", dt=dt)
-        creder = proving.credential(
-            issuer=iaid,
-            schema=schema,
-            recipient=recp,
-            data=data,
-            source={},
-            status=registry["regk"],
-        )
+            csigers = helpers.sign(bran=isalt, pidx=0, ridx=0, ser=creder.raw)
 
-        csigers = helpers.sign(bran=isalt, pidx=0, ridx=0, ser=creder.raw)
+            # Test no backers... backers would use backerIssue
+            regser = eventing.issue(vcdig=creder.said, regk=registry["regk"], dt=dt)
 
-        # Test no backers... backers would use backerIssue
-        regser = eventing.issue(vcdig=creder.said, regk=registry["regk"], dt=dt)
+            anchor = dict(i=regser.ked["i"], s=regser.ked["s"], d=regser.said)
+            serder, sigers = helpers.interact(
+                pre=iaid, bran=isalt, pidx=0, ridx=0, dig=idig, sn="2", data=[anchor]
+            )
 
-        anchor = dict(i=regser.ked["i"], s=regser.ked["s"], d=regser.said)
-        serder, sigers = helpers.interact(
-            pre=iaid, bran=isalt, pidx=0, ridx=0, dig=idig, sn="2", data=[anchor]
-        )
+            pather = coring.Pather(path=[])
 
-        pather = coring.Pather(path=[])
+            body = dict(
+                iss=regser.ked,
+                ixn=serder.ked,
+                sigs=sigers,
+                acdc=creder.sad,
+                csigs=csigers,
+                path=pather.qb64,
+            )
 
-        body = dict(
-            iss=regser.ked,
-            ixn=serder.ked,
-            sigs=sigers,
-            acdc=creder.sad,
-            csigs=csigers,
-            path=pather.qb64,
-        )
+            result = client.simulate_post(
+                path="/identifiers/badname/credentials",
+                body=json.dumps(body).encode("utf-8"),
+            )
+            assert result.status_code == 404
+            assert result.json == {
+                "description": "badname is not a valid reference to an identifier",
+                "title": "404 Not Found",
+            }
 
-        result = client.simulate_post(
-            path="/identifiers/badname/credentials",
-            body=json.dumps(body).encode("utf-8"),
-        )
-        assert result.status_code == 404
-        assert result.json == {
-            "description": "badname is not a valid reference to an identifier",
-            "title": "404 Not Found",
-        }
+            result = client.simulate_post(
+                path="/identifiers/issuer/credentials",
+                body=json.dumps(body).encode("utf-8"),
+            )
+            op = result.json
 
-        result = client.simulate_post(
-            path="/identifiers/issuer/credentials",
-            body=json.dumps(body).encode("utf-8"),
-        )
-        op = result.json
+            assert "ced" in op["metadata"]
+            assert op["metadata"]["ced"] == creder.sad
 
-        assert "ced" in op["metadata"]
-        assert op["metadata"]["ced"] == creder.sad
+            while not agent.credentialer.complete(creder.said):
+                doist.recur(deeds=agent_deeds)
 
-        while not agent.credentialer.complete(creder.said):
-            doist.recur(deeds=deeds)
+            assert agent.credentialer.complete(creder.said) is True
 
-        assert agent.credentialer.complete(creder.said) is True
+            body["acdc"]["a"]["LEI"] = "ACDC10JSON000197_"
+            result = client.simulate_post(
+                path="/identifiers/issuer/credentials",
+                body=json.dumps(body).encode("utf-8"),
+            )
+            assert result.status_code == 400
 
-        body["acdc"]["a"]["LEI"] = "ACDC10JSON000197_"
-        result = client.simulate_post(
-            path="/identifiers/issuer/credentials",
-            body=json.dumps(body).encode("utf-8"),
-        )
-        assert result.status_code == 400
+            # Try to load into another agent after TEL query without IPEX
+            agent1.parser.parse(ims=agent.hby.habByName("issuer").replay())
+            assert iaid in agent1.hby.kevers
 
-        # Try to load into another agent after TEL query without IPEX
-        agent1.parser.parse(ims=agent.hby.habByName("issuer").replay())
-        assert iaid in agent1.hby.kevers
+            agent1.parser.parse(ims=agent.rgy.reger.cloneTvtAt(registry["regk"]))
+            assert registry["regk"] in agent1.rgy.tevers
 
-        agent1.parser.parse(ims=agent.rgy.reger.cloneTvtAt(registry["regk"]))
-        assert registry["regk"] in agent1.rgy.tevers
+            agent1.parser.parse(ims=agent.rgy.reger.cloneTvtAt(creder.said))
+            assert agent1.rgy.tevers[registry["regk"]].vcSn(creder.said) is not None
 
-        agent1.parser.parse(ims=agent.rgy.reger.cloneTvtAt(creder.said))
-        assert agent1.rgy.tevers[registry["regk"]].vcSn(creder.said) is not None
+            credVerifyEnd = credentialing.CredentialVerificationCollectionEnd()
+            app1.add_route("/credentials/verify", credVerifyEnd)
 
-        credVerifyEnd = credentialing.CredentialVerificationCollectionEnd()
-        app1.add_route("/credentials/verify", credVerifyEnd)
+            body = dict(acdc=creder.sad, iss=regser.ked)  # still has changed LEI
+            result = client1.simulate_post(
+                path="/credentials/verify", body=json.dumps(body).encode("utf-8")
+            )
+            assert result.status_code == 400
 
-        body = dict(acdc=creder.sad, iss=regser.ked)  # still has changed LEI
-        result = client1.simulate_post(
-            path="/credentials/verify", body=json.dumps(body).encode("utf-8")
-        )
-        assert result.status_code == 400
+            body["acdc"]["a"]["LEI"] = "254900DA0GOGCFVWB618"  # change back
+            result = client1.simulate_post(
+                path="/credentials/verify", body=json.dumps(body).encode("utf-8")
+            )
+            assert result.status_code == 202
 
-        body["acdc"]["a"]["LEI"] = "254900DA0GOGCFVWB618"  # change back
-        result = client1.simulate_post(
-            path="/credentials/verify", body=json.dumps(body).encode("utf-8")
-        )
-        assert result.status_code == 202
-
-        deeds = doist.enter(doers=[agent1])
-        while not agent1.rgy.reger.creds.get(keys=(creder.said,)):
-            doist.recur(deeds=deeds)
+            verify_deeds = doist.enter(doers=[agent1])
+            while not agent1.rgy.reger.creds.get(keys=(creder.said,)):
+                doist.recur(deeds=verify_deeds)
+        finally:
+            if verify_deeds is not None:
+                doist.exit(deeds=verify_deeds)
+            doist.exit(deeds=agent_deeds)
 
 
 def test_credentialing_ends(helpers, seeder):
@@ -687,200 +691,403 @@ def test_revoke_credential(helpers, seeder):
 
         seeder.seedSchema(agent.hby.db)
 
-        # create the server that will receive the credential issuance messages
-        serverDoer = helpers.server(agency)
-
         tock = 0.03125
         limit = 1.0
         doist = doing.Doist(limit=limit, tock=tock, real=True)
-        deeds = doist.enter(doers=[agent, serverDoer])
+        agent_deeds = doist.enter(doers=[agent])
+        try:
+            isalt = b"0123456789abcdef"
+            registry, issuer = helpers.createRegistry(
+                client, agent, isalt, doist, agent_deeds
+            )
 
-        isalt = b"0123456789abcdef"
-        registry, issuer = helpers.createRegistry(client, agent, isalt, doist, deeds)
+            iaid = issuer["prefix"]
+            idig = issuer["state"]["d"]
 
-        iaid = issuer["prefix"]
-        idig = issuer["state"]["d"]
+            rsalt = b"abcdef0123456789"
+            op = helpers.createAid(client, "recipient", rsalt)
+            aid = op["response"]
+            recp = aid["i"]
+            assert recp == "EMgdjM1qALk3jlh4P2YyLRSTcjSOjLXD3e_uYpxbdbg6"
 
-        rsalt = b"abcdef0123456789"
-        op = helpers.createAid(client, "recipient", rsalt)
-        aid = op["response"]
-        recp = aid["i"]
-        assert recp == "EMgdjM1qALk3jlh4P2YyLRSTcjSOjLXD3e_uYpxbdbg6"
+            helpers.createEndRole(client, agent, recp, "recipient", rsalt)
 
-        helpers.createEndRole(client, agent, recp, "recipient", rsalt)
+            dt = "2021-01-01T00:00:00.000000+00:00"
+            schema = "EFgnk_c08WmZGgv9_mpldibRuqFMTQN-rAgtD-TCOwbs"
+            data = dict(LEI="254900DA0GOGCFVWB618", dt=dt)
+            creder = proving.credential(
+                issuer=iaid,
+                schema=schema,
+                recipient=recp,
+                data=data,
+                source={},
+                status=registry["regk"],
+            )
 
-        dt = "2021-01-01T00:00:00.000000+00:00"
-        schema = "EFgnk_c08WmZGgv9_mpldibRuqFMTQN-rAgtD-TCOwbs"
-        data = dict(LEI="254900DA0GOGCFVWB618", dt=dt)
-        creder = proving.credential(
-            issuer=iaid,
-            schema=schema,
-            recipient=recp,
-            data=data,
-            source={},
-            status=registry["regk"],
-        )
+            csigers = helpers.sign(bran=isalt, pidx=0, ridx=0, ser=creder.raw)
 
-        csigers = helpers.sign(bran=isalt, pidx=0, ridx=0, ser=creder.raw)
+            # Test no backers... backers would use backerIssue
+            regser = eventing.issue(vcdig=creder.said, regk=registry["regk"], dt=dt)
 
-        # Test no backers... backers would use backerIssue
-        regser = eventing.issue(vcdig=creder.said, regk=registry["regk"], dt=dt)
+            anchor = dict(i=regser.ked["i"], s=regser.ked["s"], d=regser.said)
+            serder, sigers = helpers.interact(
+                pre=iaid, bran=isalt, pidx=0, ridx=0, dig=idig, sn="2", data=[anchor]
+            )
 
-        anchor = dict(i=regser.ked["i"], s=regser.ked["s"], d=regser.said)
-        serder, sigers = helpers.interact(
-            pre=iaid, bran=isalt, pidx=0, ridx=0, dig=idig, sn="2", data=[anchor]
-        )
+            pather = coring.Pather(path=[])
 
-        pather = coring.Pather(path=[])
+            body = dict(
+                iss=regser.ked,
+                ixn=serder.ked,
+                sigs=sigers,
+                acdc=creder.sad,
+                csigs=csigers,
+                path=pather.qb64,
+            )
 
-        body = dict(
-            iss=regser.ked,
-            ixn=serder.ked,
-            sigs=sigers,
-            acdc=creder.sad,
-            csigs=csigers,
-            path=pather.qb64,
-        )
+            result = client.simulate_post(
+                path="/identifiers/badname/credentials",
+                body=json.dumps(body).encode("utf-8"),
+            )
+            assert result.status_code == 404
+            assert result.json == {
+                "description": "badname is not a valid reference to an identifier",
+                "title": "404 Not Found",
+            }
 
-        result = client.simulate_post(
-            path="/identifiers/badname/credentials",
-            body=json.dumps(body).encode("utf-8"),
-        )
-        assert result.status_code == 404
-        assert result.json == {
-            "description": "badname is not a valid reference to an identifier",
-            "title": "404 Not Found",
-        }
+            result = client.simulate_post(
+                path="/identifiers/issuer/credentials",
+                body=json.dumps(body).encode("utf-8"),
+            )
+            op = result.json
 
-        result = client.simulate_post(
-            path="/identifiers/issuer/credentials",
-            body=json.dumps(body).encode("utf-8"),
-        )
-        op = result.json
+            assert "ced" in op["metadata"]
+            assert op["metadata"]["ced"] == creder.sad
 
-        assert "ced" in op["metadata"]
-        assert op["metadata"]["ced"] == creder.sad
+            while not agent.credentialer.complete(creder.said):
+                doist.recur(deeds=agent_deeds)
 
-        while not agent.credentialer.complete(creder.said):
-            doist.recur(deeds=deeds)
+            assert agent.credentialer.complete(creder.said) is True
 
-        assert agent.credentialer.complete(creder.said) is True
+            res = client.simulate_post("/credentials/query")
+            assert res.status_code == 200
+            assert len(res.json) == 1
+            assert res.json[0]["sad"]["d"] == creder.said
+            assert res.json[0]["status"]["s"] == "0"
 
-        res = client.simulate_post("/credentials/query")
-        assert res.status_code == 200
-        assert len(res.json) == 1
-        assert res.json[0]["sad"]["d"] == creder.said
-        assert res.json[0]["status"]["s"] == "0"
+            res = client.simulate_post("/credentials/query")
+            assert res.status_code == 200
+            assert len(res.json) == 1
+            assert res.json[0]["sad"]["d"] == creder.said
+            assert res.json[0]["status"]["s"] == "0"
 
-        res = client.simulate_post("/credentials/query")
-        assert res.status_code == 200
-        assert len(res.json) == 1
-        assert res.json[0]["sad"]["d"] == creder.said
-        assert res.json[0]["status"]["s"] == "0"
+            regser = eventing.revoke(
+                vcdig=creder.said, regk=registry["regk"], dig=regser.said, dt=dt
+            )
+            anchor = dict(i=regser.ked["i"], s=regser.ked["s"], d=regser.said)
+            serder, sigers = helpers.interact(
+                pre=iaid,
+                bran=isalt,
+                pidx=0,
+                ridx=0,
+                dig=serder.said,
+                sn="3",
+                data=[anchor],
+            )
 
-        regser = eventing.revoke(
-            vcdig=creder.said, regk=registry["regk"], dig=regser.said, dt=dt
-        )
-        anchor = dict(i=regser.ked["i"], s=regser.ked["s"], d=regser.said)
-        serder, sigers = helpers.interact(
-            pre=iaid, bran=isalt, pidx=0, ridx=0, dig=serder.said, sn="3", data=[anchor]
-        )
+            body = dict(rev=regser.ked, ixn=serder.ked, sigs=sigers)
+            res = client.simulate_delete(
+                path=f"/identifiers/badname/credentials/{creder.said}",
+                body=json.dumps(body).encode("utf-8"),
+            )
+            assert res.status_code == 404
+            assert res.json == {
+                "description": "badname is not a valid reference to an identifier",
+                "title": "404 Not Found",
+            }
 
-        body = dict(rev=regser.ked, ixn=serder.ked, sigs=sigers)
-        res = client.simulate_delete(
-            path=f"/identifiers/badname/credentials/{creder.said}",
-            body=json.dumps(body).encode("utf-8"),
-        )
-        assert res.status_code == 404
-        assert res.json == {
-            "description": "badname is not a valid reference to an identifier",
-            "title": "404 Not Found",
-        }
+            res = client.simulate_delete(
+                path=f"/identifiers/issuer/credentials/{regser.said}",
+                body=json.dumps(body).encode("utf-8"),
+            )
+            assert res.status_code == 404
+            assert res.json == {
+                "description": f"credential for said {regser.said} not found.",
+                "title": "404 Not Found",
+            }
 
-        res = client.simulate_delete(
-            path=f"/identifiers/issuer/credentials/{regser.said}",
-            body=json.dumps(body).encode("utf-8"),
-        )
-        assert res.status_code == 404
-        assert res.json == {
-            "description": f"credential for said {regser.said} not found.",
-            "title": "404 Not Found",
-        }
+            badrev = regser.ked.copy()
+            badrev["ri"] = "EIVtei3pGKGUw8H2Ri0h1uOevtSA6QGAq5wifbtHIaNI"
+            _, sad = coring.Saider.saidify(badrev)
 
-        badrev = regser.ked.copy()
-        badrev["ri"] = "EIVtei3pGKGUw8H2Ri0h1uOevtSA6QGAq5wifbtHIaNI"
-        _, sad = coring.Saider.saidify(badrev)
+            badbody = dict(rev=sad, ixn=serder.ked, sigs=sigers)
+            res = client.simulate_delete(
+                path=f"/identifiers/issuer/credentials/{creder.said}",
+                body=json.dumps(badbody).encode("utf-8"),
+            )
+            assert res.status_code == 404
+            assert res.json == {
+                "description": "revocation against invalid registry SAID "
+                "EIVtei3pGKGUw8H2Ri0h1uOevtSA6QGAq5wifbtHIaNI",
+                "title": "404 Not Found",
+            }
 
-        badbody = dict(rev=sad, ixn=serder.ked, sigs=sigers)
-        res = client.simulate_delete(
-            path=f"/identifiers/issuer/credentials/{creder.said}",
-            body=json.dumps(badbody).encode("utf-8"),
-        )
-        assert res.status_code == 404
-        assert res.json == {
-            "description": "revocation against invalid registry SAID "
-            "EIVtei3pGKGUw8H2Ri0h1uOevtSA6QGAq5wifbtHIaNI",
-            "title": "404 Not Found",
-        }
+            badrev = regser.ked.copy()
+            badrev["i"] = "EMgdjM1qALk3jlh4P2YyLRSTcjSOjLXD3e_uYpxbdbg6"
+            _, sad = coring.Saider.saidify(badrev)
 
-        badrev = regser.ked.copy()
-        badrev["i"] = "EMgdjM1qALk3jlh4P2YyLRSTcjSOjLXD3e_uYpxbdbg6"
-        _, sad = coring.Saider.saidify(badrev)
+            badbody = dict(rev=sad, ixn=serder.ked, sigs=sigers)
+            res = client.simulate_delete(
+                path=f"/identifiers/issuer/credentials/{creder.said}",
+                body=json.dumps(badbody).encode("utf-8"),
+            )
+            assert res.status_code == 400
+            assert res.json == {
+                "description": "invalid revocation event.",
+                "title": "400 Bad Request",
+            }
 
-        badbody = dict(rev=sad, ixn=serder.ked, sigs=sigers)
-        res = client.simulate_delete(
-            path=f"/identifiers/issuer/credentials/{creder.said}",
-            body=json.dumps(badbody).encode("utf-8"),
-        )
-        assert res.status_code == 400
-        assert res.json == {
-            "description": "invalid revocation event.",
-            "title": "400 Bad Request",
-        }
+            res = client.simulate_delete(
+                path=f"/identifiers/issuer/credentials/{creder.said}",
+                body=json.dumps(body).encode("utf-8"),
+            )
+            assert res.status_code == 200
 
-        res = client.simulate_delete(
-            path=f"/identifiers/issuer/credentials/{creder.said}",
-            body=json.dumps(body).encode("utf-8"),
-        )
-        assert res.status_code == 200
+            while not agent.registrar.complete(creder.said, sn=1):
+                doist.recur(deeds=agent_deeds)
 
-        while not agent.registrar.complete(creder.said, sn=1):
-            doist.recur(deeds=deeds)
+            res = client.simulate_post("/credentials/query")
+            assert res.status_code == 200
+            assert len(res.json) == 1
+            assert res.json[0]["sad"]["d"] == creder.said
+            assert res.json[0]["status"]["s"] == "1"
 
-        res = client.simulate_post("/credentials/query")
-        assert res.status_code == 200
-        assert len(res.json) == 1
-        assert res.json[0]["sad"]["d"] == creder.said
-        assert res.json[0]["status"]["s"] == "1"
-
-        res = client.simulate_post("/credentials/query")
-        assert res.status_code == 200
-        assert len(res.json) == 1
-        assert res.json[0]["sad"]["d"] == creder.said
-        assert res.json[0]["status"]["s"] == "1"
+            res = client.simulate_post("/credentials/query")
+            assert res.status_code == 200
+            assert len(res.json) == 1
+            assert res.json[0]["sad"]["d"] == creder.said
+            assert res.json[0]["status"]["s"] == "1"
+        finally:
+            doist.exit(deeds=agent_deeds)
 
         res = client.simulate_get(f"/registries/{registry['regk']}/{creder.said}")
         assert res.status_code == 200
         assert res.json["s"] == "1"
         assert res.json["et"] == "rev"
 
-def test_replay_multisig_embeds_restores_local_after_remote_follower_approval(
+
+def test_issue_credential_replays_multisig_embeds_before_local_approval(
+    helpers, seeder, monkeypatch
+):
+    """Follower B must replay A's stored `/multisig/iss` embeds before approval.
+
+    This is an endpoint-order test for the follower approval path in
+    `CredentialCollectionEnd.on_post(...)`.
+
+    Identity mapping:
+
+    - participant B is the local `issuer` habitat created by
+      `helpers.createRegistry(...)`.
+    - participant A is represented by the mocked `replay_multisig_embeds(...)`
+      invocation, which stands in for the already-stored remote EXN.
+    - `creder`, `iserder`, and `anc` are B's local approval payload for the
+      same issuance proposal.
+
+    We assert only the ordering guarantee that matters for this bug:
+    KERIA must replay A's stored `anc` and `acdc` streams before B's local
+    interaction approval is processed.
+    """
+    with helpers.openKeria() as (agency, agent, app, client):
+        idResEnd = aiding.IdentifierResourceEnd()
+        app.add_route("/identifiers/{name}", idResEnd)
+        registryEnd = credentialing.RegistryCollectionEnd(idResEnd)
+        app.add_route("/identifiers/{name}/registries", registryEnd)
+        credEnd = credentialing.CredentialCollectionEnd(idResEnd)
+        app.add_route("/identifiers/{name}/credentials", credEnd)
+        end = aiding.IdentifierCollectionEnd()
+        app.add_route("/identifiers", end)
+
+        seeder.seedSchema(agent.hby.db)
+
+        doist = doing.Doist(limit=1.0, tock=0.03125, real=True)
+        agent_deeds = doist.enter(doers=[agent])
+        try:
+            isalt = b"0123456789abcdef"
+            registry, follower_b_issuer = helpers.createRegistry(
+                client, agent, isalt, doist, agent_deeds
+            )
+
+            dt = "2021-01-01T00:00:00.000000+00:00"
+            creder = proving.credential(
+                issuer=follower_b_issuer["prefix"],
+                schema="EFgnk_c08WmZGgv9_mpldibRuqFMTQN-rAgtD-TCOwbs",
+                recipient=follower_b_issuer["prefix"],
+                data=dict(LEI="254900DA0GOGCFVWB618", dt=dt),
+                source={},
+                status=registry["regk"],
+            )
+            iserder = eventing.issue(vcdig=creder.said, regk=registry["regk"], dt=dt)
+            anchor = dict(i=iserder.ked["i"], s=iserder.ked["s"], d=iserder.said)
+            anc, _ = helpers.interact(
+                pre=follower_b_issuer["prefix"],
+                bran=isalt,
+                pidx=0,
+                ridx=0,
+                dig=follower_b_issuer["state"]["d"],
+                sn="2",
+                data=[anchor],
+            )
+
+            class FakeOp:
+                def to_json(self):
+                    return json.dumps(dict(name="mock-op"))
+
+            calls = []
+
+            # Participant A's fake replay
+            def fake_replay(*args, **kwargs):
+                calls.append(("replay", kwargs["route"], kwargs["labels"]))
+
+            def fake_interact(*args, **kwargs):
+                calls.append("interact")
+                return FakeOp()
+
+            monkeypatch.setattr(credentialing, "replay_multisig_embeds", fake_replay)
+            monkeypatch.setattr(idResEnd, "interact", fake_interact)
+            monkeypatch.setattr(
+                agent.credentialer, "validate", lambda *args, **kwargs: None
+            )
+            monkeypatch.setattr(
+                agent.registrar,
+                "issue",
+                lambda regk, iser, anc_serder: calls.append("registrar.issue"),
+            )
+            monkeypatch.setattr(
+                agent.credentialer,
+                "issue",
+                lambda *args, **kwargs: calls.append("credentialer.issue"),
+            )
+            monkeypatch.setattr(
+                agent.monitor,
+                "submit",
+                lambda *args, **kwargs: FakeOp(),
+            )
+
+            body = dict(acdc=creder.sad, iss=iserder.ked, ixn=anc.ked)
+            res = client.simulate_post(
+                path="/identifiers/issuer/credentials",
+                body=json.dumps(body).encode("utf-8"),
+            )
+
+            assert res.status_code == 200
+            assert calls[:2] == [
+                ("replay", "/multisig/iss", ("anc", "acdc")),
+                "interact",
+            ]
+        finally:
+            doist.exit(deeds=agent_deeds)
+
+
+def test_revoke_credential_replays_multisig_embeds_before_local_approval(
     helpers, monkeypatch
 ):
-    """A stored remote `/multisig/vcp` must replay the leader's `anc` stream.
+    """Follower B must replay A's stored `/multisig/rev` `anc` before approval.
 
-    This test is intentionally narrow. It does not try to create a full
-    multisig registry. It proves only the missing follower behavior:
+    Identity mapping mirrors the issuance test above:
 
-    1. a remote `/multisig/vcp` proposal already exists in mux storage,
-    2. the follower later approves the same proposal through the credentialing
-       path,
-    3. `replay_multisig_embeds(...)` must parse the stored remote `anc` event
-       stream (`ixn` raw bytes plus `paths["anc"]`) before local approval
-       continues.
+    - participant B is the local `issuer` habitat handled by this KERIA agent.
+    - participant A is represented by the mocked replay helper invocation.
+    - `rserder` and `anc` are B's local revocation approval payload.
 
-    That local-after-remote ordering is the case `Multiplexor.add(...)` does
-    not repair by itself.
+    The asserted behavior is that KERIA replays A's stored anchoring event
+    stream before it processes B's local interaction approval.
+    """
+    with helpers.openKeria() as (agency, agent, app, client):
+        idResEnd = aiding.IdentifierResourceEnd()
+        app.add_route("/identifiers/{name}", idResEnd)
+        registryEnd = credentialing.RegistryCollectionEnd(idResEnd)
+        app.add_route("/identifiers/{name}/registries", registryEnd)
+        credResDelEnd = credentialing.CredentialResourceDeleteEnd(idResEnd)
+        app.add_route("/identifiers/{name}/credentials/{said}", credResDelEnd)
+        end = aiding.IdentifierCollectionEnd()
+        app.add_route("/identifiers", end)
+
+        doist = doing.Doist(limit=1.0, tock=0.03125, real=True)
+        agent_deeds = doist.enter(doers=[agent])
+        try:
+            isalt = b"0123456789abcdef"
+            registry, follower_b_issuer = helpers.createRegistry(
+                client, agent, isalt, doist, agent_deeds
+            )
+
+            dt = "2021-01-01T00:00:00.000000+00:00"
+            creder = proving.credential(
+                issuer=follower_b_issuer["prefix"],
+                schema="EFgnk_c08WmZGgv9_mpldibRuqFMTQN-rAgtD-TCOwbs",
+                recipient=follower_b_issuer["prefix"],
+                data=dict(LEI="254900DA0GOGCFVWB618", dt=dt),
+                source={},
+                status=registry["regk"],
+            )
+            iserder = eventing.issue(vcdig=creder.said, regk=registry["regk"], dt=dt)
+            rserder = eventing.revoke(
+                vcdig=creder.said, regk=registry["regk"], dig=iserder.said, dt=dt
+            )
+            anchor = dict(i=rserder.ked["i"], s=rserder.ked["s"], d=rserder.said)
+            anc, _ = helpers.interact(
+                pre=follower_b_issuer["prefix"],
+                bran=isalt,
+                pidx=0,
+                ridx=0,
+                dig=follower_b_issuer["state"]["d"],
+                sn="2",
+                data=[anchor],
+            )
+
+            class FakeOp:
+                def to_json(self):
+                    return json.dumps(dict(name="mock-op"))
+
+            calls = []
+
+            # Participant A modeled as a fake replay
+            def fake_replay(*args, **kwargs):
+                calls.append(("replay", kwargs["route"], kwargs["labels"]))
+
+            def fake_interact(*args, **kwargs):
+                calls.append("interact")
+                return FakeOp()
+
+            monkeypatch.setattr(credentialing, "replay_multisig_embeds", fake_replay)
+            monkeypatch.setattr(idResEnd, "interact", fake_interact)
+            monkeypatch.setattr(
+                agent.rgy.reger, "cloneCreds", lambda *args, **kwargs: []
+            )
+            monkeypatch.setattr(
+                agent.registrar,
+                "revoke",
+                lambda regk, rser, anc_ked: calls.append("registrar.revoke"),
+            )
+
+            body = dict(rev=rserder.ked, ixn=anc.ked)
+            res = client.simulate_delete(
+                path=f"/identifiers/issuer/credentials/{creder.said}",
+                body=json.dumps(body).encode("utf-8"),
+            )
+
+            assert res.status_code == 200
+            assert calls[:2] == [("replay", "/multisig/rev", ("anc",)), "interact"]
+        finally:
+            doist.exit(deeds=agent_deeds)
+
+
+def test_keria_registrar_issue_starts_counselor_for_multisig_hab(monkeypatch):
+    """Registrar.issue must start counselor tracking for multisig issuance.
+
+    This is the post-replay side of the same mental model. Once the follower
+    approval path has assembled the shared anchoring event for the group, the
+    registrar still must start counselor tracking for the group's anchoring
+    event. Otherwise the TEL issuance event can remain stuck in multisig escrow.
     """
 
     class FakeSignifyGroupHab:
@@ -888,83 +1095,60 @@ def test_replay_multisig_embeds_restores_local_after_remote_follower_approval(
 
     monkeypatch.setattr(credentialing, "SignifyGroupHab", FakeSignifyGroupHab)
 
-    with helpers.openKeria() as (agency, agent, app, client):
-        end = aiding.IdentifierCollectionEnd()
-        app.add_route("/identifiers", end)
+    regser = eventing.incept(
+        "EHgwVwQT15OJvilVvW57HE4w0-GPs_Stj2OFoAHZSysY",
+        baks=[],
+        toad="0",
+        nonce=Salter().qb64,
+        cnfg=[TraitCodex.NoBackers],
+        code=coring.MtrDex.Blake3_256,
+    )
+    iserder = eventing.issue(
+        vcdig=regser.said, regk=regser.pre, dt="2021-01-01T00:00:00.000000+00:00"
+    )
+    anc = SimpleNamespace(sn=3, said=iserder.said)
 
-        # Build a realistic registry proposal payload using a real AID and a
-        # real anchoring interaction event. This keeps the test concrete while
-        # avoiding a full live multisig stack.
-        salt = b"0123456789abcdef"
-        op = helpers.createAid(client, "test", salt)
-        aid = op["response"]
-        pre = aid["i"]
+    counselor_calls = []
+    tmse_entries = []
 
-        nonce = Salter().qb64
-        regser = eventing.incept(
-            pre,
-            baks=[],
-            toad="0",
-            nonce=nonce,
-            cnfg=[TraitCodex.NoBackers],
-            code=coring.MtrDex.Blake3_256,
-        )
-        anchor = dict(i=regser.ked["i"], s=regser.ked["s"], d=regser.said)
-        ixn, _ = helpers.interact(
-            pre=pre, bran=salt, pidx=0, ridx=0, dig=aid["d"], sn="1", data=[anchor]
-        )
+    hab = FakeSignifyGroupHab()
+    hab.name = "issuer-group"
+    hab.pre = "EHgwVwQT15OJvilVvW57HE4w0-GPs_Stj2OFoAHZSysY"
 
-        # This is the same approval payload shape the follower later submits to
-        # `POST /identifiers/{name}/registries`: a VCP plus the anchoring event
-        # carried under the EXN protocol label `anc`.
-        follower_approval_payload = dict(vcp=regser.ked, anc=ixn.ked)
+    registry = SimpleNamespace(
+        hab=hab,
+        processEvent=lambda serder: None,
+    )
+    registrar = credentialing.Registrar(
+        agentHab=None,
+        hby=None,
+        rgy=SimpleNamespace(
+            regs={regser.pre: registry},
+            reger=SimpleNamespace(
+                tmse=SimpleNamespace(
+                    add=lambda keys, val: tmse_entries.append((keys, val))
+                )
+            ),
+        ),
+        counselor=SimpleNamespace(
+            start=lambda **kwargs: counselor_calls.append(kwargs)
+        ),
+        witDoer=None,
+        witPub=None,
+        verifier=None,
+    )
 
-        # `replay_multisig_embeds(...)` derives the embedded-section SAID from
-        # that approval payload, then asks mux for stored EXNs for the same
-        # logical proposal.
-        embed_ked = dict(follower_approval_payload)
-        embed_ked["d"] = ""
-        _, embed_ked = coring.Saider.saidify(sad=embed_ked, label=coring.Saids.d)
-        proposal_esaid = embed_ked["d"]
+    vcid, sn = registrar.issue(regser.pre, iserder, anc)
 
-        parsed_message_streams = []
-
-        class RecordingParser:
-            def parseOne(self, ims):
-                parsed_message_streams.append(bytes(ims))
-
-        class StoredRemoteProposalMux:
-            def get(self, esaid):
-                assert esaid == proposal_esaid
-                return [
-                    dict(
-                        exn={"r": "/multisig/vcp", "i": "remote-member-pre"},
-                        paths={"anc": "FAKE-REMOTE-ANC-ATC"},
-                    )
-                ]
-
-        # Simulate the follower-side KERIA view:
-        # - mux already has a stored remote `/multisig/vcp`
-        # - the parser will record exactly what the helper replays
-        fake_agent = SimpleNamespace(
-            mux=StoredRemoteProposalMux(),
-            hby=SimpleNamespace(psr=RecordingParser()),
-        )
-        hab = FakeSignifyGroupHab()
-        hab.mhab = SimpleNamespace(pre="local-member-pre")
-
-        replays = credentialing.replay_multisig_embeds(
-            fake_agent,
-            hab,
-            route="/multisig/vcp",
-            embeds=follower_approval_payload,
-            labels=("anc",),
-        )
-
-        # The replayed byte stream must be the leader's anchoring event stream:
-        # the `ixn` raw bytes followed by the stored remote attachment group.
-        expected_remote_anc_stream = bytearray(serdering.SerderKERI(sad=ixn.ked).raw)
-        expected_remote_anc_stream.extend(b"FAKE-REMOTE-ANC-ATC")
-
-        assert replays == 1
-        assert parsed_message_streams == [bytes(expected_remote_anc_stream)]
+    assert (vcid, sn) == (iserder.ked["i"], coring.Seqner(snh=iserder.ked["s"]).sn)
+    assert len(counselor_calls) == 1
+    assert counselor_calls[0]["ghab"] is hab
+    assert counselor_calls[0]["prefixer"].qb64 == hab.pre
+    assert counselor_calls[0]["seqner"].sn == anc.sn
+    assert counselor_calls[0]["saider"].qb64 == anc.said
+    assert len(tmse_entries) == 1
+    assert tmse_entries[0][0] == (
+        iserder.ked["i"],
+        coring.Seqner(snh=iserder.ked["s"]).qb64,
+        iserder.said,
+    )

--- a/tests/app/test_grouping.py
+++ b/tests/app/test_grouping.py
@@ -9,6 +9,7 @@ Testing the Mark II Agent Grouping endpoints
 
 import json
 
+from keri import kering
 from keri.app.habbing import SignifyGroupHab
 from keri.core import eventing, coring
 from keri.peer import exchanging
@@ -303,3 +304,93 @@ def test_join(helpers, monkeypatch):
             "description": "attempt to create identifier with an already used alias or prefix mms",
             "title": "400 Bad Request",
         }
+
+
+def test_join_reports_missing_group_kel_as_conflict(helpers, monkeypatch):
+    with helpers.openKeria() as (agency, agent, app, client):
+        grouping.loadEnds(app)
+
+        end = aiding.IdentifierCollectionEnd()
+        resend = aiding.IdentifierResourceEnd()
+        app.add_route("/identifiers", end)
+        app.add_route("/identifiers/{name}", resend)
+
+        salt = b"0123456789abcdef"
+        op = helpers.createAid(client, "recipient", salt)
+        aid = op["response"]
+
+        body = dict(
+            rot={
+                "v": "KERI10JSON00030c_",
+                "t": "rot",
+                "d": "EPKCBT0rSgFKTDRjynYzOTsYWo7fDNElTxFbRZZW9f6R",
+                "i": "EDWg3-rB5FTpcckaYdBcexGmbLIO6AvAwjaJTBlXUn_I",
+                "s": "3",
+                "p": "EM2OaIZuLWyGGyxf4Tzs6yeoENvjP47i1Dn88GGxw3_Z",
+                "kt": ["0", "0", "1/2", "1/2", "1/2", "1/2"],
+                "k": [
+                    "DNp1NUbUEgei6KOlIfT5evXueOi3TDFZkUXgJQWNvegf",
+                    "DLsXs0-dxqrM4hugX7NkfZUzET13ngfRhWC9GgXvX9my",
+                    "DE2W_yGSF-m44vXPuQ5_wHJ9EK59N-OIT3hABgdAcCKs",
+                    "DKFKNK7s0xLhazlmL3xH9YEl9sc3fVoqUSsQxK6DZ3oC",
+                    "DEyEcy5NzjqA3KQ1DTE0BJs-XMIdWIvPWligyq6y1TxS",
+                    "DGhflVckn2wVLJH6wq94gGQxmpvsFdsZvd61Owj3Qhjl",
+                ],
+                "nt": ["1/2", "1/2", "1/2", "1/2"],
+                "n": [
+                    "EDr0gf60BDB9cZyVoz_Os55Ma49muyCNTZoWG-VWAe6g",
+                    "EIM3hKH1VBG_ofS7hD-XMfTG-dP1ziJwloFhrNx34G7o",
+                    "EOi609MGQlByLPdaUgqGQn_IOEE4cf6u7zCW-J3E82Qz",
+                    "ECQF1Tdpcqew6dqN6nHNpz4jhYTZtojl7EpqVJhXRBav",
+                ],
+                "bt": "3",
+                "br": [],
+                "ba": [],
+                "a": [],
+            },
+            sigs=[],
+            gid="EDWg3-rB5FTpcckaYdBcexGmbLIO6AvAwjaJTBlXUn_I",
+            smids=[
+                aid["i"],
+                "EJccSRTfXYF6wrUVuenAIHzwcx3hJugeiJsEKmndi5q1",
+                "EBFg-5SGDCv5YfwpkArWRBdTxNRUXU8uVcDKNzizOQZc",
+                "EBmW2bXbgsP3HITwW3FmITzAb3wVmHlxCusZ46vgGgP5",
+                "EL4RpdS2Atb2Syu5xLdpz9CcNNYoFUUDlLHxHD09vcgh",
+                "EAiBVuuhCZrgckeHc9KzROVGJpmGbk2-e1B25GaeRrJs",
+            ],
+            rmids=[
+                aid["i"],
+                "EJccSRTfXYF6wrUVuenAIHzwcx3hJugeiJsEKmndi5q1",
+                "EBFg-5SGDCv5YfwpkArWRBdTxNRUXU8uVcDKNzizOQZc",
+                "EBmW2bXbgsP3HITwW3FmITzAb3wVmHlxCusZ46vgGgP5",
+                "EL4RpdS2Atb2Syu5xLdpz9CcNNYoFUUDlLHxHD09vcgh",
+                "EAiBVuuhCZrgckeHc9KzROVGJpmGbk2-e1B25GaeRrJs",
+            ],
+        )
+
+        for smid in body["smids"]:
+            agent.hby.kevers[smid] = {}
+
+        for rmid in body["rmids"]:
+            agent.hby.kevers[rmid] = {}
+
+        def make(self, serder, sigers):
+            raise kering.ValidationError(
+                f"Improper Habitat event type={serder.ked['t']} for pre={self.pre}."
+            )
+
+        monkeypatch.setattr(SignifyGroupHab, "make", make)
+
+        res = client.simulate_post("/identifiers/mms/multisig/join", json=body)
+        assert res.status_code == 409
+        assert res.json == {
+            "title": "409 Conflict",
+            "description": "multisig join for group "
+            "EDWg3-rB5FTpcckaYdBcexGmbLIO6AvAwjaJTBlXUn_I is missing prior group "
+            "events needed to process rotation sn=3; query key state/logs for "
+            "EDWg3-rB5FTpcckaYdBcexGmbLIO6AvAwjaJTBlXUn_I through sn=3 and retry "
+            "join",
+        }
+
+        res = client.simulate_post("/identifiers/mms/multisig/join", json=body)
+        assert res.status_code == 409

--- a/tests/app/test_multisig.py
+++ b/tests/app/test_multisig.py
@@ -1,0 +1,308 @@
+# -*- encoding: utf-8 -*-
+"""
+KERIA
+keria.app.multisig module
+
+Focused tests for replaying stored multisig embedded event streams.
+"""
+
+from types import SimpleNamespace
+
+from keri.core import coring, eventing as core_eventing, serdering
+from keri.core.signing import Salter
+from keri.kering import TraitCodex
+from keri.vc import proving
+from keri.vdr import eventing as veventing
+
+from keria.app import aiding, multisig
+
+
+def _replay_streams(monkeypatch, *, route, embeds, labels, paths):
+    """Simulate follower B replaying a proposal that leader A sent earlier.
+
+    This helper is the shared fixture for the route-specific replay tests
+    below. It intentionally models the exact local-after-remote ordering that
+    the KLI uses in JoinDoer:
+
+    1. participant A already sent `/multisig/*` and that EXN is stored in mux
+       storage,
+    2. participant B later approves the same proposal locally,
+    3. KERIA must replay A's stored embedded event stream before it can finish
+       B's approval.
+
+    Identity mapping used throughout this helper:
+
+    - `StoredRemoteProposalMux` is participant A's already-stored proposal.
+    - `fake_agent` is participant B's KERIA agent at approval time.
+    - `hab.mhab.pre` is participant B's member AID, which is why the replay
+      helper skips EXNs authored by that same prefix.
+
+    The returned `parsed_message_streams` list is therefore the exact stream
+    KERIA replays for participant B from participant A's stored EXN.
+    """
+
+    class FakeSignifyGroupHab:
+        pass
+
+    monkeypatch.setattr(multisig, "SignifyGroupHab", FakeSignifyGroupHab)
+
+    embed_ked = dict(embeds)
+    embed_ked["d"] = ""
+    _, embed_ked = coring.Saider.saidify(sad=embed_ked, label=coring.Saids.d)
+    proposal_esaid = embed_ked["d"]
+
+    parsed_message_streams = []
+
+    # Simple parser mock for testing
+    class RecordingParser:
+        def parseOne(self, ims):
+            parsed_message_streams.append(bytes(ims))
+
+    # Multiplexor mock  for simple testing
+    class StoredRemoteProposalMux:
+        def get(self, esaid):
+            assert esaid == proposal_esaid
+            return [
+                dict(
+                    # Participant A's previously received multisig EXN. The
+                    # route and attachments here are the canonical remote
+                    # proposal participant B must replay before B continues
+                    # with local approval.
+                    exn={"r": route, "i": "remote-member-a-pre"},
+                    paths=paths,
+                )
+            ]
+
+    # This fake agent is participant B's KERIA process when B later approves
+    # the same proposal through a local HTTP route such as `/registries` or
+    # `/credentials`.
+    fake_agent = SimpleNamespace(
+        mux=StoredRemoteProposalMux(),
+        hby=SimpleNamespace(psr=RecordingParser()),
+    )
+    hab = FakeSignifyGroupHab()
+    hab.mhab = SimpleNamespace(pre="local-member-b-pre")
+
+    replays = multisig.replay_multisig_embeds(
+        fake_agent,
+        hab,
+        route=route,
+        embeds=embeds,
+        labels=labels,
+    )
+
+    return replays, parsed_message_streams
+
+
+def test_replay_multisig_embeds_replays_stored_remote_vcp_anc_stream(
+    helpers, monkeypatch
+):
+    """Follower B must replay leader A's stored `anc` stream for `/multisig/vcp`.
+
+    The concrete fixture objects are:
+
+    - `regser` and `anc`: the proposal participant B is about to approve.
+    - `paths["anc"]`: participant A's previously stored signature attachments.
+    - `_replay_streams(...)`: participant B's KERIA view at approval time.
+
+    The assertion proves that B replays A's exact anchoring event stream,
+    meaning the raw `ixn` bytes plus A's attachment group.
+    """
+    with helpers.openKeria() as (_, __, app, client):
+        app.add_route("/identifiers", aiding.IdentifierCollectionEnd())
+
+        salt = b"0123456789abcdef"
+        op = helpers.createAid(client, "test", salt)
+        aid = op["response"]
+        follower_member_b_pre = aid["i"]
+
+        regser = veventing.incept(
+            follower_member_b_pre,
+            baks=[],
+            toad="0",
+            nonce=Salter().qb64,
+            cnfg=[TraitCodex.NoBackers],
+            code=coring.MtrDex.Blake3_256,
+        )
+        anchor = dict(i=regser.ked["i"], s=regser.ked["s"], d=regser.said)
+        anc, _ = helpers.interact(
+            pre=follower_member_b_pre,
+            bran=salt,
+            pidx=0,
+            ridx=0,
+            dig=aid["d"],
+            sn="1",
+            data=[anchor],
+        )
+
+        replays, parsed_streams = _replay_streams(
+            monkeypatch,
+            route="/multisig/vcp",
+            embeds=dict(vcp=regser.ked, anc=anc.ked),
+            labels=("anc",),
+            paths={"anc": "FAKE-REMOTE-ANC-ATC"},
+        )
+
+        expected = bytearray(serdering.SerderKERI(sad=anc.ked).raw)
+        expected.extend(b"FAKE-REMOTE-ANC-ATC")
+
+        assert replays == 1
+        assert parsed_streams == [bytes(expected)]
+
+
+def test_replay_multisig_embeds_replays_stored_remote_rpy_stream(helpers, monkeypatch):
+    """Follower B must replay leader A's stored `rpy` stream for `/multisig/rpy`.
+
+    The locally built `rserder` stands in for the exact reply participant B is
+    about to endorse. The stored `paths["rpy"]` attachment group represents the
+    signature material that already came from participant A's earlier EXN.
+    """
+    with helpers.openKeria() as (_, agent, app, client):
+        app.add_route("/identifiers", aiding.IdentifierCollectionEnd())
+
+        salt = b"0123456789abcdef"
+        op = helpers.createAid(client, "user1", salt)
+        aid = op["response"]
+        rserder = helpers.endrole(aid["i"], agent.agentHab.pre)
+
+        replays, parsed_streams = _replay_streams(
+            monkeypatch,
+            route="/multisig/rpy",
+            embeds=dict(rpy=rserder.ked),
+            labels=("rpy",),
+            paths={"rpy": "FAKE-REMOTE-RPY-ATC"},
+        )
+
+        expected = bytearray(serdering.SerderKERI(sad=rserder.ked).raw)
+        expected.extend(b"FAKE-REMOTE-RPY-ATC")
+
+        assert replays == 1
+        assert parsed_streams == [bytes(expected)]
+
+
+def test_replay_multisig_embeds_replays_stored_remote_issue_streams(
+    helpers, monkeypatch
+):
+    """Follower B must replay A's `anc` and `acdc` streams for `/multisig/iss`.
+
+    This is the most subtle replay case:
+
+    - `anc` is the anchoring KEL event that both participants must mirror.
+    - `acdc` is the credential payload stream participant A already attached.
+    - participant B replays both before B's local issuance approval continues.
+    """
+    with helpers.openKeria() as (_, __, app, client):
+        app.add_route("/identifiers", aiding.IdentifierCollectionEnd())
+
+        salt = b"0123456789abcdef"
+        op = helpers.createAid(client, "issuer", salt)
+        aid = op["response"]
+        follower_member_b_pre = aid["i"]
+
+        regser = veventing.incept(
+            follower_member_b_pre,
+            baks=[],
+            toad="0",
+            nonce=Salter().qb64,
+            cnfg=[TraitCodex.NoBackers],
+            code=coring.MtrDex.Blake3_256,
+        )
+        creder = proving.credential(
+            issuer=follower_member_b_pre,
+            schema="EFgnk_c08WmZGgv9_mpldibRuqFMTQN-rAgtD-TCOwbs",
+            recipient=follower_member_b_pre,
+            data=dict(
+                LEI="254900DA0GOGCFVWB618", dt="2021-01-01T00:00:00.000000+00:00"
+            ),
+            source={},
+            status=regser.pre,
+        )
+        iserder = veventing.issue(
+            vcdig=creder.said,
+            regk=regser.pre,
+            dt="2021-01-01T00:00:00.000000+00:00",
+        )
+        anchor = dict(i=iserder.ked["i"], s=iserder.ked["s"], d=iserder.said)
+        anc, _ = helpers.interact(
+            pre=follower_member_b_pre,
+            bran=salt,
+            pidx=0,
+            ridx=0,
+            dig=aid["d"],
+            sn="1",
+            data=[anchor],
+        )
+
+        replays, parsed_streams = _replay_streams(
+            monkeypatch,
+            route="/multisig/iss",
+            embeds=dict(acdc=creder.sad, iss=iserder.ked, anc=anc.ked),
+            labels=("anc", "acdc"),
+            paths={
+                "anc": "FAKE-REMOTE-ANC-ATC",
+                "acdc": "FAKE-REMOTE-ACDC-ATC",
+            },
+        )
+
+        expected_anc = bytearray(serdering.SerderKERI(sad=anc.ked).raw)
+        expected_anc.extend(b"FAKE-REMOTE-ANC-ATC")
+        expected_acdc = bytearray(serdering.SerderACDC(sad=creder.sad).raw)
+        expected_acdc.extend(b"FAKE-REMOTE-ACDC-ATC")
+
+        assert replays == 1
+        assert parsed_streams == [bytes(expected_anc), bytes(expected_acdc)]
+
+
+def test_replay_multisig_embeds_replays_stored_remote_rev_anc_stream(
+    helpers, monkeypatch
+):
+    """Follower B must replay A's stored anchoring event for `/multisig/rev`.
+
+    Revocation only needs the previously stored `anc` stream replayed before
+    participant B processes the local revocation approval.
+    """
+    with helpers.openKeria() as (_, __, app, client):
+        app.add_route("/identifiers", aiding.IdentifierCollectionEnd())
+
+        salt = b"0123456789abcdef"
+        op = helpers.createAid(client, "issuer", salt)
+        aid = op["response"]
+        follower_member_b_pre = aid["i"]
+
+        regser = veventing.incept(
+            follower_member_b_pre,
+            baks=[],
+            toad="0",
+            nonce=Salter().qb64,
+            cnfg=[TraitCodex.NoBackers],
+            code=coring.MtrDex.Blake3_256,
+        )
+        issue_serder = veventing.issue(
+            vcdig=regser.said,
+            regk=regser.pre,
+            dt="2021-01-01T00:00:00.000000+00:00",
+        )
+        rserder = veventing.revoke(
+            vcdig=regser.said,
+            regk=regser.pre,
+            dig=issue_serder.said,
+            dt="2021-01-01T00:00:00.000000+00:00",
+        )
+        anchor = dict(i=rserder.ked["i"], s=rserder.ked["s"], d=rserder.said)
+        anc = core_eventing.interact(
+            pre=follower_member_b_pre, dig=aid["d"], sn=1, data=[anchor]
+        )
+
+        replays, parsed_streams = _replay_streams(
+            monkeypatch,
+            route="/multisig/rev",
+            embeds=dict(rev=rserder.ked, anc=anc.ked),
+            labels=("anc",),
+            paths={"anc": "FAKE-REMOTE-ANC-ATC"},
+        )
+
+        expected = bytearray(serdering.SerderKERI(sad=anc.ked).raw)
+        expected.extend(b"FAKE-REMOTE-ANC-ATC")
+
+        assert replays == 1
+        assert parsed_streams == [bytes(expected)]

--- a/tests/core/test_longrunning.py
+++ b/tests/core/test_longrunning.py
@@ -1,4 +1,10 @@
+import datetime
+from types import SimpleNamespace
+
 from keri.help import helping
+from keri.core import coring
+from keri.db import dbing
+from keri.vdr import eventing
 
 import pytest
 from keria.app import aiding
@@ -469,11 +475,301 @@ def test_error(helpers):
             "title": "long running operation 'exchange.EBfdlu8R27Fbx-ehrqwImnK-8Cm79sqbAQ4MmvEAYqao' not found"
         }
 
-        res = client.simulate_get(
-            path="/operations/query.EBfdlu8R27Fbx-ehrqwImnK-8Cm79sqbAQ4MmvEAYqao"
+
+def test_regsync_status(helpers):
+    with helpers.openKeria() as (agency, agent, app, client):
+        pre = agent.agentHab.pre
+        regk = "ERegsyncRegistry0000000000000000000000000000000000000"
+        agent.registrar.rgy.reger._tevers = {}
+        base = dict(
+            pre=pre,
+            source="ESource000000000000000000000000000000000000000",
+            request="ERequest00000000000000000000000000000000000000",
+            targets=[],
+            error=None,
         )
-        assert res.status_code == 404
-        assert res.json == {
-            "title": "long running operation "
-            "'query.EBfdlu8R27Fbx-ehrqwImnK-8Cm79sqbAQ4MmvEAYqao' not found"
+
+        pending_catalog = agent.monitor.status(
+            longrunning.Op(
+                type=longrunning.OpTypes.regsync,
+                oid=pre,
+                start=helping.nowIso8601(),
+                metadata={
+                    **base,
+                    "phase": "catalog",
+                    "phase_start": helping.nowIso8601(),
+                },
+            )
+        )
+        assert pending_catalog.name == f"regsync.{pre}"
+        assert pending_catalog.done is False
+
+        timed_out_catalog = agent.monitor.status(
+            longrunning.Op(
+                type=longrunning.OpTypes.regsync,
+                oid=pre,
+                start=helping.nowIso8601(),
+                metadata={
+                    **base,
+                    "phase": "catalog",
+                    "phase_start": helping.toIso8601(
+                        helping.nowUTC() - datetime.timedelta(seconds=11)
+                    ),
+                },
+            )
+        )
+        assert timed_out_catalog.done is True
+        assert timed_out_catalog.error.code == 504
+
+        agent.rgy.regs[regk] = SimpleNamespace(name="registry", regk=regk)
+        agent.rgy.tevers[regk] = SimpleNamespace(sn=0)
+        pending_replay = agent.monitor.status(
+            longrunning.Op(
+                type=longrunning.OpTypes.regsync,
+                oid=pre,
+                start=helping.nowIso8601(),
+                metadata={
+                    **base,
+                    "phase": "replay",
+                    "phase_start": helping.nowIso8601(),
+                    "targets": [dict(name="registry", regk=regk, sn=1)],
+                },
+            )
+        )
+        assert pending_replay.done is False
+
+        agent.rgy.tevers[regk] = SimpleNamespace(sn=1)
+        completed_replay = agent.monitor.status(
+            longrunning.Op(
+                type=longrunning.OpTypes.regsync,
+                oid=pre,
+                start=helping.nowIso8601(),
+                metadata={
+                    **base,
+                    "phase": "replay",
+                    "phase_start": helping.nowIso8601(),
+                    "targets": [dict(name="registry", regk=regk, sn=1)],
+                },
+            )
+        )
+        assert completed_replay.done is True
+        assert completed_replay.response == {
+            "pre": pre,
+            "source": base["source"],
+            "synced": [dict(name="registry", regk=regk, sn=1)],
         }
+
+        failed = agent.monitor.status(
+            longrunning.Op(
+                type=longrunning.OpTypes.regsync,
+                oid=pre,
+                start=helping.nowIso8601(),
+                metadata={
+                    **base,
+                    "phase": "catalog",
+                    "phase_start": helping.nowIso8601(),
+                    "error": dict(code=424, message="bad response", details={"regk": regk}),
+                },
+            )
+        )
+        assert failed.done is True
+        assert failed.error.code == 424
+        assert failed.error.details == {"regk": regk}
+
+
+def test_regsync_backfills_registry_anchor(helpers, monkeypatch):
+    with helpers.openKeria() as (agency, agent, app, client):
+        pre = agent.agentHab.pre
+        regk = "ERegsyncAnchor00000000000000000000000000000000000000"
+        regd = "ERegsyncAnchorSaid0000000000000000000000000000000000"
+        seal = dict(i=regk, s="0", d=regd)
+        source_serder = agent.agentHab.kever.serder
+
+        agent.registrar.rgy.reger._tevers = {}
+        agent.rgy.regs[regk] = SimpleNamespace(name="registry", regk=regk)
+        agent.rgy.tevers[regk] = SimpleNamespace(sn=0)
+
+        monkeypatch.setattr(
+            agent.hby.db,
+            "fetchLastSealingEventByEventSeal",
+            lambda pre, seal: source_serder,
+        )
+
+        op = agent.monitor.status(
+            longrunning.Op(
+                type=longrunning.OpTypes.regsync,
+                oid=pre,
+                start=helping.nowIso8601(),
+                metadata=dict(
+                    pre=pre,
+                    source="ESource000000000000000000000000000000000000000",
+                    phase="replay",
+                    phase_start=helping.nowIso8601(),
+                    request="ERequest00000000000000000000000000000000000000",
+                    targets=[dict(name="registry", regk=regk, regd=regd, anc=seal, sn=0)],
+                    error=None,
+                ),
+            )
+        )
+
+        assert op.done is True
+        assert (
+            agent.rgy.reger.getAnc(dbing.dgKey(regk, regd))
+            == coring.Seqner(sn=source_serder.sn).qb64b
+            + coring.Saider(qb64=source_serder.said).qb64b
+        )
+
+
+def test_credsync_backfills_tel_anchor(helpers, monkeypatch):
+    with helpers.openKeria() as (agency, agent, app, client):
+        gid = agent.agentHab.pre
+        source_serder = agent.agentHab.kever.serder
+        rserder = eventing.revoke(
+            vcdig=source_serder.said,
+            regk=source_serder.said,
+            dig=source_serder.said,
+            dt="2023-09-27T16:27:14.376928+00:00",
+        )
+        seal = dict(i=rserder.pre, s=rserder.snh, d=rserder.said)
+
+        monkeypatch.setattr(
+            agent.hby.db,
+            "fetchLastSealingEventByEventSeal",
+            lambda pre, seal: source_serder,
+        )
+
+        assert (
+            longrunning.ensure_tel_anchor(
+                hby=agent.hby,
+                reger=agent.rgy.reger,
+                gid=gid,
+                pre=rserder.pre,
+                said=rserder.said,
+                anchor=seal,
+            )
+            is True
+        )
+        assert (
+            agent.rgy.reger.getAnc(dbing.dgKey(rserder.pre, rserder.said))
+            == coring.Seqner(sn=source_serder.sn).qb64b
+            + coring.Saider(qb64=source_serder.said).qb64b
+        )
+
+
+def test_credsync_status(helpers, monkeypatch):
+    with helpers.openKeria() as (agency, agent, app, client):
+        pre = agent.agentHab.pre
+        regk = "ECredsyncRegistry00000000000000000000000000000000000"
+        said = "ECredsyncCredential0000000000000000000000000000000"
+        base = dict(
+            pre=pre,
+            source="ESource000000000000000000000000000000000000000",
+            phase="replay",
+            phase_start=helping.nowIso8601(),
+            request="ERequest00000000000000000000000000000000000000",
+            saids=[said],
+            synced=[],
+            error=None,
+        )
+
+        original_saved = agent.registrar.rgy.reger.saved
+        original_clone_cred = agent.registrar.rgy.reger.cloneCred
+        original_tevers = agent.registrar.rgy.reger._tevers
+        try:
+            agent.registrar.rgy.reger._tevers = {}
+            agent.registrar.rgy.reger.saved = SimpleNamespace(get=lambda keys: None)
+            pending = agent.monitor.status(
+                longrunning.Op(
+                    type=longrunning.OpTypes.credsync,
+                    oid=pre,
+                    start=helping.nowIso8601(),
+                    metadata=base,
+                )
+            )
+            assert pending.name == f"credsync.{pre}"
+            assert pending.done is False
+
+            agent.registrar.rgy.reger.saved = SimpleNamespace(
+                get=lambda keys: said if keys == (said,) else None
+            )
+            agent.registrar.rgy.reger.cloneCred = lambda said: (
+                SimpleNamespace(regi=regk, sad={"ri": regk}),
+                None,
+                None,
+                None,
+            )
+            agent.rgy.regs[regk] = SimpleNamespace(name="registry", regk=regk)
+            ready = False
+            escrow_calls = []
+
+            monkeypatch.setattr(
+                agent.registrar.rgy,
+                "processEscrows",
+                lambda: escrow_calls.append("rgy"),
+            )
+            monkeypatch.setattr(
+                agent.credentialer.verifier,
+                "processEscrows",
+                lambda: escrow_calls.append("verifier"),
+            )
+            monkeypatch.setattr(
+                agent.registrar,
+                "processEscrows",
+                lambda: escrow_calls.append("registrar"),
+            )
+            monkeypatch.setattr(
+                agent.credentialer,
+                "processEscrows",
+                lambda: escrow_calls.append("credentialer"),
+            )
+            agent.registrar.rgy.reger._tevers[regk] = SimpleNamespace(
+                vcState=lambda vci: SimpleNamespace(sn=0, et="iss") if ready else None
+            )
+
+            pending_tel = agent.monitor.status(
+                longrunning.Op(
+                    type=longrunning.OpTypes.credsync,
+                    oid=pre,
+                    start=helping.nowIso8601(),
+                    metadata=base,
+                )
+            )
+            assert pending_tel.done is False
+            assert escrow_calls == ["rgy", "verifier", "registrar", "credentialer"]
+
+            ready = True
+            escrow_calls.clear()
+            completed = agent.monitor.status(
+                longrunning.Op(
+                    type=longrunning.OpTypes.credsync,
+                    oid=pre,
+                    start=helping.nowIso8601(),
+                    metadata={**base, "synced": [said]},
+                )
+            )
+            assert completed.done is True
+            assert escrow_calls == ["rgy", "verifier", "registrar", "credentialer"]
+            assert completed.response == {
+                "pre": pre,
+                "source": base["source"],
+                "synced": [said],
+            }
+
+            failed = agent.monitor.status(
+                longrunning.Op(
+                    type=longrunning.OpTypes.credsync,
+                    oid=pre,
+                    start=helping.nowIso8601(),
+                    metadata={
+                        **base,
+                        "error": dict(code=424, message="bad response", details={"said": said}),
+                    },
+                )
+            )
+            assert failed.done is True
+            assert failed.error.code == 424
+            assert failed.error.details == {"said": said}
+        finally:
+            agent.registrar.rgy.reger.saved = original_saved
+            agent.registrar.rgy.reger.cloneCred = original_clone_cred
+            agent.registrar.rgy.reger._tevers = original_tevers


### PR DESCRIPTION
There is an anchoring interaction event replay gap in how KERIA processes multisig events compared to how the KLI, with the JoinDoer in join.py, is used in the KERIpy Multiplexor implementation. 

This is a bit complicated. Here's the critical part that I discovered was missing. The issue description below goes into a lot more detail.

### Critical: what was missing - Processing of the multisig registry event initiator's ixn signature

The existing KERIA code for group multisig handling does not properly handle event initiator signatures. It accidentally works for groups of size three or more due to how `/multisig/*` event handling works with KERIpy's `Multiplexor.add()` function. The problem is most severe for multisig groups with only two members.

The existing `GroupRequester` Doer, a generic multisig/group event handling doer, in KERIA accepts a property labeled "group" of metadata including the interaction event signed at the edge. When submitted by the second, third, or later group member as an approval of the registry inception event then the existing KERIA generic event handling in GroupRequester would receive the interaction event and processes it yet that would only include the signature of the local participant (Member 2, 3, etc.), not the originator's signature.

So, the initiators signature would never be processed in multisig groups of two and would only accidentally be processed in groups of three or more since Multiplexor.add(), from the third group member, would correctly handle the embedded initiator `ixn` and initiator signature in the `/multisig/vcp` exn message.

This affects more than `/multisig/vcp` messages. The solution is to mirror the KLI's JoinDoer multisig functionality. I break this down below.

### Issue definition for Registry inception (applies to other evt types as well)

KERIpy's Multiplexor works well for the **initiator**/**leader** of a KERIA multisig operation, but not the KERIA joiner. KERIA splits up the joiner side across four files whereas the JoinDoer in the KLI has everything in one place, which is likely how this bug crept in.

The KLI puts the **joiner**/**follower** side in the `kli multisig join` KLI command, specifically in the match statement in JoinDoer.joinDo that should likely be refactored into `keri.app` or `keri.core`. KLI keeps the whole follower choreography in one place: `JoinDoer`

KERIA splits the choreography across:
- EXN intake
- registry approval
- identifier interaction
- registrar escrow handling

Meaning, specifically, the following files:

- `/identifiers/{name}/multisig/request` in grouping.py (line 39)
  - parses and stores the EXN envelope plus attachments
- `makeSignifyRegistry(...)` in credentialing.py (line 91)
  - processes the vcp
- `IdentifierResourceEnd.interact(...)` in aiding.py (line 1186)
  - processes the follower’s edge-signed ixn, the **approval** from the SignifyClient
- `Registrar.incept(...)` in credentialing.py (line 1423)
  - handles registry anchoring workflow

That split is fine in principle. The problem was that one critical KLI step had no KERIA analog to the following KLI behavior:
- replay stored remote anc attachments
  - parse the remote stored anc stream (ixn.raw + paths["anc"]) from the initiator 
  - processing the follower’s local approval.


So replay_multisig_embeds(...) below is not redundant. It is the missing glue between:
- stored EXN state
- and follower approval state

### Further description

This fixes a bug for each non-KEL multisig event type including vcp, iss, rev, and rpy, not just multisig registry creation (vcp). This would primarily affect **two member** multisig groups where the operation would stall out due to the vcp/iss/rev/rpy timing out on a missing anchor escrow because the event seal not being recognized by the joiners (followers) of the multisig operation due to not being parsed from the original exn message from the multisig operation leader.

What would happen is this (the bug/failure flow):
- For the initiator (leader) of the multisig operation they would anchor the vcp/iss/rev event in an interaction event.
- This `ixn` event would be wrapped in an exchange `exn` message envelope to be sent to the other participants on the `/multisig/vcp` route, or similar. The initiator would save the event seal locally because it created the event. Multiplexor.add() facilitates this.

- the followers would receive the `/multisig/vcp` exn message but would not parse the attachments because they needed to wait for the local SignifyController's group member to approve the registry inception.
  - this places the interaction event anchoring the multisig vcp in escrow
- following local event approval the group member would then handle the registry creation and anchoring locally yet would wait forever (in multisig groups of two) for the initiator's anchoring interaction event to be processed.

### Accidental Rescue in groups of more than 2 members

KERIpy's `Multiplexor.add(...)` can sometimes accidentally rescue a follower, but only in a very specific way, for multisig groups with more than two members, not by retroactively replaying the original stored leader EXN, but by:
- parsing a later-arriving equivalent multisig EXN for the same embedded proposal,
  - which carries the same anchoring event SAD plus a different member’s signatures/attachments.

Since each member in a multisig group, in response to the `/multisig/vcp` from the leader would send out its own `/multisig/vcp` exn, then the third member would essentially allow the Multiplexor on the second member to "rescue" its infinite hang operation.

### Takeaway

The takeaway is this:
- For followers/non-initiators, replaying the stored, non-local, embedded anchoring event and its attachments, which **critically** include the initiator's signature over the anchoring interaction (ixn) event, is **required** during follower approval  of `/multisig/vcp`, `/multisig/iss`, rev, and rpy flows to complete handling and avoid indefinite anchor escrow processing which typically surfaces as a process hang.