### PR TITLE
Drain imported CESR before registry rename

### DIFF
--- a/src/keria/app/credentialing.py
+++ b/src/keria/app/credentialing.py
@@ -575,6 +575,10 @@ class RegistryResourceEnd:
         if "name" not in body:
             raise falcon.HTTPBadRequest(description="'name' is required in body")
 
+        # Drain any just-imported CESR before aliasing an imported registry as local.
+        if agent.parser.ims:
+            agent.parser.parse()
+
         name = body["name"]
         if agent.rgy.registryByName(name) is not None:
             raise falcon.HTTPBadRequest(


### PR DESCRIPTION
References WebOfTrust/keria#316.

This drains any CESR bytes queued by an agent import before the registry rename endpoint aliases an imported registry as local. In the late-join multisig flow, the credential CESR import can queue TEL material and the immediate registry rename can otherwise cause the queued issue event to be parsed under local registry handling.

The change keeps the import/rename ordering deterministic without changing the public API.