### PR TITLE
chore: fix depends type in some operation metadata

### DIFF
--- a/src/keria/app/specing.py
+++ b/src/keria/app/specing.py
@@ -881,18 +881,6 @@ class AgentSpecResource:
                 {"$ref": "#/components/schemas/ACDC_V_2"},
             ]
         }
-        self.spec.components.schemas["CredentialOperationMetadata"]["properties"][
-            "depends"
-        ] = {
-            "oneOf": [
-                {"$ref": "#/components/schemas/ROT_V_1"},
-                {"$ref": "#/components/schemas/ROT_V_2"},
-                {"$ref": "#/components/schemas/DRT_V_1"},
-                {"$ref": "#/components/schemas/DRT_V_2"},
-                {"$ref": "#/components/schemas/IXN_V_1"},
-                {"$ref": "#/components/schemas/IXN_V_2"},
-            ]
-        }
         self.spec.components.schema(
             "CredentialOperationResponse",
             schema=marshmallow_dataclass.class_schema(
@@ -968,13 +956,7 @@ class AgentSpecResource:
         )
         self.spec.components.schemas["DelegatorOperationMetadata"]["properties"][
             "depends"
-        ] = {
-            "oneOf": [
-                {"$ref": "#/components/schemas/GroupOperation"},
-                {"$ref": "#/components/schemas/WitnessOperation"},
-                {"$ref": "#/components/schemas/DoneOperation"},
-            ]
-        }
+        ] = {"$ref": "#/components/schemas/KelOperation"}
 
         self.spec.components.schema(
             "PendingDelegatorOperation",
@@ -1001,6 +983,22 @@ class AgentSpecResource:
                 {"$ref": "#/components/schemas/FailedDelegatorOperation"},
             ]
         }
+
+        self.spec.components.schemas["KelOperation"] = {
+            "oneOf": [
+                {"$ref": "#/components/schemas/GroupOperation"},
+                {"$ref": "#/components/schemas/WitnessOperation"},
+                {"$ref": "#/components/schemas/DoneOperation"},
+                {"$ref": "#/components/schemas/DelegationOperation"},
+                {"$ref": "#/components/schemas/SubmitOperation"},
+            ]
+        }
+        self.spec.components.schemas["RegistryOperationMetadata"]["properties"][
+            "depends"
+        ] = {"$ref": "#/components/schemas/KelOperation"}
+        self.spec.components.schemas["CredentialOperationMetadata"]["properties"][
+            "depends"
+        ] = {"$ref": "#/components/schemas/KelOperation"}
 
         self.spec.components.schemas["Operation"] = {
             "oneOf": [

--- a/src/keria/app/specing.py
+++ b/src/keria/app/specing.py
@@ -990,7 +990,6 @@ class AgentSpecResource:
                 {"$ref": "#/components/schemas/WitnessOperation"},
                 {"$ref": "#/components/schemas/DoneOperation"},
                 {"$ref": "#/components/schemas/DelegationOperation"},
-                {"$ref": "#/components/schemas/SubmitOperation"},
             ]
         }
         self.spec.components.schemas["RegistryOperationMetadata"]["properties"][

--- a/src/keria/core/optypes.py
+++ b/src/keria/core/optypes.py
@@ -334,60 +334,6 @@ GroupOperation = Union[
 
 
 @dataclass
-class DelegatorOperationMetadata:
-    pre: str
-    teepre: str
-    anchor: credentialing.Anchor = field(
-        default_factory=credentialing.Anchor,
-        metadata={
-            "marshmallow_field": fields.Nested(
-                class_schema(credentialing.Anchor), required=False
-            )
-        },
-    )
-    depends: Union["GroupOperation", "WitnessOperation", "DoneOperation"] = None  # type: ignore
-
-
-@dataclass
-class BaseDelegatorOperation:
-    metadata: DelegatorOperationMetadata = field(
-        default_factory=DelegatorOperationMetadata,
-        metadata={
-            "marshmallow_field": fields.Nested(
-                class_schema(DelegatorOperationMetadata), required=False
-            )
-        },
-    )
-
-
-@dataclass
-class PendingDelegatorOperation(BaseDelegatorOperation, PendingOperation):
-    pass
-
-
-@dataclass(kw_only=True)
-class CompletedDelegatorOperation(BaseDelegatorOperation, CompletedOperation):
-    response: str
-
-
-@dataclass(kw_only=True)
-class FailedDelegatorOperation(BaseDelegatorOperation, FailedOperation):
-    error: OperationStatus = field(
-        default=None,
-        metadata={
-            "marshmallow_field": fields.Nested(
-                class_schema(OperationStatus), required=True
-            )
-        },
-    )
-
-
-DelegatorOperation = Union[
-    PendingDelegatorOperation, CompletedDelegatorOperation, FailedDelegatorOperation
-]
-
-
-@dataclass
 class SubmitOperationMetadata:
     pre: str
     sn: int
@@ -436,6 +382,68 @@ class FailedSubmitOperation(BaseSubmitOperation, FailedOperation):
 
 SubmitOperation = Union[
     PendingSubmitOperation, CompletedSubmitOperation, FailedSubmitOperation
+]
+
+KelOperation = Union[
+    "GroupOperation",
+    "WitnessOperation",
+    "DoneOperation",
+    "DelegationOperation",
+    "SubmitOperation",
+]
+
+
+@dataclass
+class DelegatorOperationMetadata:
+    pre: str
+    teepre: str
+    anchor: credentialing.Anchor = field(
+        default_factory=credentialing.Anchor,
+        metadata={
+            "marshmallow_field": fields.Nested(
+                class_schema(credentialing.Anchor), required=False
+            )
+        },
+    )
+    depends: KelOperation = None  # type: ignore
+
+
+@dataclass
+class BaseDelegatorOperation:
+    metadata: DelegatorOperationMetadata = field(
+        default_factory=DelegatorOperationMetadata,
+        metadata={
+            "marshmallow_field": fields.Nested(
+                class_schema(DelegatorOperationMetadata), required=False
+            )
+        },
+    )
+
+
+@dataclass
+class PendingDelegatorOperation(BaseDelegatorOperation, PendingOperation):
+    pass
+
+
+@dataclass(kw_only=True)
+class CompletedDelegatorOperation(BaseDelegatorOperation, CompletedOperation):
+    response: str
+
+
+@dataclass(kw_only=True)
+class FailedDelegatorOperation(BaseDelegatorOperation, FailedOperation):
+    error: OperationStatus = field(
+        default=None,
+        metadata={
+            "marshmallow_field": fields.Nested(
+                class_schema(OperationStatus), required=True
+            )
+        },
+    )
+
+
+DelegatorOperation = Union[
+    PendingDelegatorOperation, CompletedDelegatorOperation, FailedDelegatorOperation
 ]
 
 
@@ -597,9 +605,7 @@ ChallengeOperation = Union[
 @dataclass
 class RegistryOperationMetadata:
     pre: str
-    depends: Union[
-        "GroupOperation", "WitnessOperation", "DoneOperation", "DelegationOperation"
-    ]
+    depends: KelOperation = None  # type: ignore
     anchor: Anchor = field(
         default_factory=Anchor,
         metadata={
@@ -667,7 +673,7 @@ RegistryOperation = Union[
 @dataclass
 class CredentialOperationMetadata:
     ced: Union[ACDC_V_1, ACDC_V_2]  # type: ignore
-    depends: Union[ROT_V_1, ROT_V_2, DRT_V_1, DRT_V_2, IXN_V_1, IXN_V_2] = None  # type: ignore
+    depends: KelOperation = None  # type: ignore
 
 
 @dataclass

--- a/src/keria/core/optypes.py
+++ b/src/keria/core/optypes.py
@@ -333,63 +333,11 @@ GroupOperation = Union[
 ]
 
 
-@dataclass
-class SubmitOperationMetadata:
-    pre: str
-    sn: int
-
-
-@dataclass
-class BaseSubmitOperation:
-    metadata: SubmitOperationMetadata = field(
-        default_factory=SubmitOperationMetadata,
-        metadata={
-            "marshmallow_field": fields.Nested(
-                class_schema(SubmitOperationMetadata), required=False
-            )
-        },
-    )
-
-
-@dataclass
-class PendingSubmitOperation(BaseSubmitOperation, PendingOperation):
-    pass
-
-
-@dataclass(kw_only=True)
-class CompletedSubmitOperation(BaseSubmitOperation, CompletedOperation):
-    response: KeyStateRecord = field(
-        default=None,
-        metadata={
-            "marshmallow_field": fields.Nested(
-                class_schema(KeyStateRecord), required=True
-            )
-        },
-    )
-
-
-@dataclass(kw_only=True)
-class FailedSubmitOperation(BaseSubmitOperation, FailedOperation):
-    error: OperationStatus = field(
-        default=None,
-        metadata={
-            "marshmallow_field": fields.Nested(
-                class_schema(OperationStatus), required=True
-            )
-        },
-    )
-
-
-SubmitOperation = Union[
-    PendingSubmitOperation, CompletedSubmitOperation, FailedSubmitOperation
-]
-
 KelOperation = Union[
     "GroupOperation",
     "WitnessOperation",
     "DoneOperation",
     "DelegationOperation",
-    "SubmitOperation",
 ]
 
 
@@ -444,6 +392,58 @@ class FailedDelegatorOperation(BaseDelegatorOperation, FailedOperation):
 
 DelegatorOperation = Union[
     PendingDelegatorOperation, CompletedDelegatorOperation, FailedDelegatorOperation
+]
+
+
+@dataclass
+class SubmitOperationMetadata:
+    pre: str
+    sn: int
+
+
+@dataclass
+class BaseSubmitOperation:
+    metadata: SubmitOperationMetadata = field(
+        default_factory=SubmitOperationMetadata,
+        metadata={
+            "marshmallow_field": fields.Nested(
+                class_schema(SubmitOperationMetadata), required=False
+            )
+        },
+    )
+
+
+@dataclass
+class PendingSubmitOperation(BaseSubmitOperation, PendingOperation):
+    pass
+
+
+@dataclass(kw_only=True)
+class CompletedSubmitOperation(BaseSubmitOperation, CompletedOperation):
+    response: KeyStateRecord = field(
+        default=None,
+        metadata={
+            "marshmallow_field": fields.Nested(
+                class_schema(KeyStateRecord), required=True
+            )
+        },
+    )
+
+
+@dataclass(kw_only=True)
+class FailedSubmitOperation(BaseSubmitOperation, FailedOperation):
+    error: OperationStatus = field(
+        default=None,
+        metadata={
+            "marshmallow_field": fields.Nested(
+                class_schema(OperationStatus), required=True
+            )
+        },
+    )
+
+
+SubmitOperation = Union[
+    PendingSubmitOperation, CompletedSubmitOperation, FailedSubmitOperation
 ]
 
 


### PR DESCRIPTION
Adds a common `KelOperation` which also helps type generation in Java.