### PR TITLE
docs: fix documentation badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # KERIA
 [![GitHub Actions](https://github.com/webOfTrust/keria/actions/workflows/python-app-ci.yml/badge.svg)](https://github.com/WebOfTrust/keria/actions)
 [![codecov](https://codecov.io/gh/WebOfTrust/keria/branch/main/graph/badge.svg?token=FR5CB2TPYG)](https://codecov.io/gh/WebOfTrust/keria)
-[![Documentation Status](https://readthedocs.org/projects/keria/badge/?version=latest)](https://keria.readthedocs.io/en/latest/?badge=latest)
+[![Documentation Status](https://img.shields.io/readthedocs/keria/latest)](https://keria.readthedocs.io/en/latest/)
 
 KERI Agent in the cloud
 


### PR DESCRIPTION
Fix the failing documentation badge in the KERIA README.

The old badge URL at `readthedocs.org/projects/keria/badge/` now redirects to `app.readthedocs.org` (Read the Docs new app domain) which triggers a Cloudflare challenge and never resolves to an SVG badge. The actual docs site at `keria.readthedocs.io/en/latest/` still works.

Replaced with a shields.io Read the Docs badge (`img.shields.io/readthedocs/keria/latest`) which resolves correctly.

## Scope
- README badge/link update only
- No source code changes
- No config changes
- No dependency changes

## Validation
- `git diff --check`
- shields.io badge URL returns HTTP 200
- keria.readthedocs.io target URL returns HTTP 200

References #319.