### PR TITLE
feat: suppress redundant IPEX initiator notifications

### DIFF
--- a/docs/keria_notifications.md
+++ b/docs/keria_notifications.md
@@ -87,8 +87,6 @@ Here's the breakdown for each of the exn route types:
 - `/delegate/request`: 
   - Handled by `DelegateRequestHandler` - creates a notification for the delegator only.
   - Only one event type, the delegation request.
-- `/oobis`: 
-  - Handled by `OobiRequestHandler`, though is not currently registered. No notification needed for OOBI resolution.
 
 ### Route attribute for exchange message routing
 

--- a/src/keria/app/agenting.py
+++ b/src/keria/app/agenting.py
@@ -47,7 +47,6 @@ from keri.core import coring, parsing, eventing, routing, serdering
 from keri.core.coring import Ilks
 from keri.core.signing import Salter
 from keri.db.basing import OobiRecord
-from keri.vc import protocoling
 
 from keria.end import ending
 from keri.help import helping, nowIso8601
@@ -727,7 +726,7 @@ class Agent(doing.DoDoer):
         self.exc = exchanging.Exchanger(hby=hby, handlers=handlers)
         grouping.loadHandlers(exc=self.exc, mux=self.mux)
         kdelegating.loadHandlers(hby=self.hby, exc=self.exc, notifier=self.notifier)
-        protocoling.loadHandlers(hby=self.hby, exc=self.exc, notifier=self.notifier)
+        ipexing.loadHandlers(hby=self.hby, exc=self.exc, notifier=self.notifier)
         self.submitter = Submitter(
             hby=hby, submits=self.submits, witRec=self.witSubmitDoer
         )

--- a/src/keria/app/ipexing.py
+++ b/src/keria/app/ipexing.py
@@ -12,8 +12,41 @@ from keri.app import habbing
 from keri.core import eventing, serdering
 from keri.vdr import credentialing
 from keri.peer import exchanging
+from keri.vc import protocoling
 
 from keria.core import httping, longrunning
+
+
+IPEX_ROUTES = (
+    "/ipex/apply",
+    "/ipex/offer",
+    "/ipex/agree",
+    "/ipex/grant",
+    "/ipex/admit",
+    "/ipex/spurn",
+)
+
+
+class IpexNotificationHandler(protocoling.IpexHandler):
+    """IPEX handler that suppresses notifications for locally originated EXNs."""
+
+    def handle(self, serder, attachments=None):
+        # Checking if the message sender AID (serder.pre) is local and, if so, skip making a
+        # notification. This prevents a redundant notification appearing for an IPEX operation
+        # initiator.
+        if serder.pre in self.hby.habs:
+            return
+
+        # Call superclass handler to create notification when sender is not a local AID.
+        super().handle(serder=serder, attachments=attachments)
+
+
+def loadHandlers(hby, exc, notifier):
+    """Load IPEX handlers with KERIA notification semantics."""
+    for route in IPEX_ROUTES:
+        exc.addHandler(
+            IpexNotificationHandler(resource=route, hby=hby, notifier=notifier)
+        )
 
 
 def loadEnds(app):


### PR DESCRIPTION
IPEX operation initiators do not need notifications of events they create as it is redundant. Suppressing notifications for IPEX operations like this, for initiators, is similar to how Multiplexor in KERIpy suppresses notifications for multisig operation initiators.

https://github.com/WebOfTrust/signify-ts/pull/399/changes can be moved from draft to PR once this is merged.