### PR TITLE
chore(openapi): emit const booleans for operation done status instead of enums

### DIFF
--- a/src/keria/app/specing.py
+++ b/src/keria/app/specing.py
@@ -11,7 +11,7 @@ from ..core import optypes
 from ..utils.openapi import applyAltConstraintsToOpenApiSchema
 from . import credentialing
 from keri.core import coring
-from ..utils.openapi import enumSchemaFromNamedtuple
+from ..utils.openapi import enumSchemaFromNamedtuple, constFromMetadata
 
 """
 KERIA
@@ -31,12 +31,15 @@ class AgentSpecResource:
     """
 
     def __init__(self, app, title, version="1.0.1", openapi_version="3.1.0"):
+        marshmallowPlugin = MarshmallowPlugin()
         self.spec = APISpec(
             title=title,
             version=version,
             openapi_version=openapi_version,
-            plugins=[MarshmallowPlugin()],
+            plugins=[marshmallowPlugin],
         )
+
+        marshmallowPlugin.converter.add_attribute_function(constFromMetadata)
 
         # Register marshmallow schemas (pass class)
         self.spec.components.schema("ACDC_V_1", schema=credentialing.ACDCSchema_V_1)

--- a/src/keria/core/longrunning.py
+++ b/src/keria/core/longrunning.py
@@ -66,21 +66,38 @@ class BaseOperation:
 @dataclass_json
 @dataclass
 class PendingOperation(BaseOperation):
-    done: Literal[False] = False
+    done: Literal[False] = field(
+        default=False,
+        metadata={
+            "marshmallow_field": fields.Boolean(
+                required=True, metadata={"const": False}
+            )
+        },
+    )
 
 
 @dataclass_json
 @dataclass
 class CompletedOperation(BaseOperation):
     response: dict
-    done: Literal[True] = True
+    done: Literal[True] = field(
+        default=True,
+        metadata={
+            "marshmallow_field": fields.Boolean(required=True, metadata={"const": True})
+        },
+    )
 
 
 @dataclass_json
 @dataclass
 class FailedOperation(BaseOperation):
     error: OperationStatus
-    done: Literal[True] = True
+    done: Literal[True] = field(
+        default=True,
+        metadata={
+            "marshmallow_field": fields.Boolean(required=True, metadata={"const": True})
+        },
+    )
 
 
 Operation = Union[PendingOperation, CompletedOperation, FailedOperation]

--- a/src/keria/core/optypes.py
+++ b/src/keria/core/optypes.py
@@ -605,7 +605,7 @@ ChallengeOperation = Union[
 @dataclass
 class RegistryOperationMetadata:
     pre: str
-    depends: KelOperation = None  # type: ignore
+    depends: KelOperation  # type: ignore
     anchor: Anchor = field(
         default_factory=Anchor,
         metadata={

--- a/src/keria/utils/openapi.py
+++ b/src/keria/utils/openapi.py
@@ -434,3 +434,15 @@ def namedtupleToEnum(nt_instance, enum_name="AutoEnum"):
 
     # Dynamically create a subclass of str & Enum
     return Enum(enum_name, members, type=str)
+
+
+def constFromMetadata(self, field, **kwargs):
+    """Emit JSON-Schema ``const`` from ``metadata={"const": <value>}`` on any field.
+
+    apispec's metadata passthrough drops ``const`` because its allowlist predates
+    OpenAPI 3.1, so a fixed value (e.g. operation ``done``) would otherwise render as
+    an unconstrained type. ``self`` is the converter apispec binds this to.
+    """
+    if "const" in field.metadata:
+        return {"const": field.metadata["const"]}
+    return {}


### PR DESCRIPTION
For operations, the done field in the openapi spec was an enum with a single field of false or true for pending or complete operations. This was problematic for Signify-Java.

This change emits a constant boolean instead so both Signify-TS and Signify-Java get proper booleans for the done field.