### PR TITLE
fix: prevent stale group credential acceptance blocking issuance

### DIFF
--- a/src/keria/app/credentialing.py
+++ b/src/keria/app/credentialing.py
@@ -10,7 +10,7 @@ import json
 from dataclasses import asdict, dataclass, field
 
 import falcon
-from keri import kering, help
+from keri import core, help, kering
 from keri.app import signing
 from keri.app.habbing import SignifyGroupHab
 from keri.core import coring, scheming, serdering
@@ -57,7 +57,7 @@ def loadEnds(app, identifierResource):
     app.add_route("/identifiers/{name}/credentials", credentialCollectionEnd)
 
     credentialRegistryResEnd = CredentialRegistryResourceEnd()
-    app.add_route("/registries/{ri}/{vci}", credentialRegistryResEnd)
+    app.add_route("/registries/{ri}/{credential_said}", credentialRegistryResEnd)
 
     credentialResourceEnd = CredentialResourceEnd()
     app.add_route("/credentials/{said}", credentialResourceEnd)
@@ -849,6 +849,103 @@ class CredentialQueryCollectionEnd:
         rep.data = json.dumps(creds).encode("utf-8")
 
 
+def _telEventSaidProcessed(
+    reger: viring.Reger,
+    credential_said: str,
+    serder: serdering.SerderKERI,
+) -> bool:
+    """Return True when a TEL event with the same SAID already exists."""
+    return reger.getTvt(key=dbing.dgKey(credential_said, serder.said)) is not None
+
+
+def _validateTelAnchor(tel, anc):
+    anchor = dict(i=tel.ked["i"], s=tel.ked["s"], d=tel.said)
+    if anchor not in anc.ked.get("a", []):
+        raise falcon.HTTPBadRequest(
+            description="KEL event does not anchor the submitted TEL event"
+        )
+
+
+def _parseCredentialAnchor(body):
+    if "rot" in body:
+        raise falcon.HTTPBadRequest(
+            description="credential operations only support interaction anchors"
+        )
+    if "ixn" not in body:
+        raise falcon.HTTPBadRequest(
+            description="credential operations require an interaction anchor"
+        )
+
+    try:
+        anc = serdering.SerderKERI(sad=httping.getRequiredParam(body, "ixn"))
+        sigers = [
+            core.Siger(qb64=sig) for sig in httping.getRequiredParam(body, "sigs")
+        ]
+    except (kering.ValidationError, ValueError) as e:
+        raise falcon.HTTPBadRequest(description=e.args[0])
+
+    if not sigers:
+        raise falcon.HTTPBadRequest(
+            description="credential operations require interaction signatures"
+        )
+
+    return anc, sigers
+
+
+def _groupKelRecorded(agent, ghab, anc):
+    dig = agent.hby.db.getKeLast(key=dbing.snKey(pre=ghab.pre, sn=anc.sn))
+    if dig is None:
+        return False
+    if bytes(dig).decode("utf-8") != anc.said:
+        raise falcon.HTTPConflict(
+            description=f"group KEL event at sequence {anc.sn} does not match submitted event"
+        )
+    return True
+
+
+def _validateGroupTelAnchor(agent, ghab, tel, anc):
+    if anc.pre != ghab.pre:
+        raise falcon.HTTPBadRequest(
+            description="KEL event does not belong to the registry controller"
+        )
+    if anc.ilk != coring.Ilks.ixn:
+        raise falcon.HTTPBadRequest(description="KEL event must be an interaction")
+    if not _groupKelRecorded(agent, ghab, anc) and anc.sn != ghab.kever.sn + 1:
+        raise falcon.HTTPConflict(
+            description="KEL event sequence is not the next group event"
+        )
+    _validateTelAnchor(tel, anc)
+
+
+def _startGroupKel(agent, ghab, anc, sigers):
+    if not _groupKelRecorded(agent, ghab, anc):
+        ghab.interact(serder=anc, sigers=sigers)
+
+    agent.counselor.start(
+        ghab=ghab,
+        prefixer=coring.Prefixer(qb64=ghab.pre),
+        seqner=coring.Seqner(sn=anc.sn),
+        saider=coring.Saider(qb64=anc.said),
+    )
+
+
+def _groupCredentialOperation(agent, credential_said, tel, anc, creder=None):
+    metadata = dict(
+        group=dict(pre=anc.pre, sn=anc.sn, said=anc.said),
+        tel=dict(
+            sn=coring.Number(numh=tel.ked["s"]).sn,
+            said=tel.said,
+        ),
+    )
+    if creder is not None:
+        metadata["ced"] = creder.sad
+    else:
+        metadata["credential_said"] = credential_said
+    return agent.monitor.submit(
+        credential_said, longrunning.OpTypes.credential, metadata=metadata
+    )
+
+
 class CredentialCollectionEnd:
     def __init__(self, identifierResource):
         """
@@ -923,6 +1020,8 @@ class CredentialCollectionEnd:
                     application/json:
                         schema:
                             $ref: '#/components/schemas/CredentialOperation'
+            202:
+                description: Group credential issuance accepted.
             400:
                 description: Bad request. This could be due to missing or invalid data.
 
@@ -939,17 +1038,21 @@ class CredentialCollectionEnd:
             raise falcon.HTTPNotFound(
                 description=f"{name} is not a valid reference to an identifier"
             )
+        if hab.kever.estOnly:
+            raise falcon.HTTPBadRequest(
+                description=(
+                    "credential issuance for establishment-only identifiers is not "
+                    "supported"
+                )
+            )
         try:
             creder = serdering.SerderACDC(sad=httping.getRequiredParam(body, "acdc"))
             iserder = serdering.SerderKERI(sad=httping.getRequiredParam(body, "iss"))
-            if "ixn" in body:
-                anc = serdering.SerderKERI(sad=httping.getRequiredParam(body, "ixn"))
-            else:
-                anc = serdering.SerderKERI(sad=httping.getRequiredParam(body, "rot"))
         except (kering.ValidationError, json.decoder.JSONDecodeError) as e:
             rep.status = falcon.HTTP_400
             rep.text = e.args[0]
             return
+        anc, sigers = _parseCredentialAnchor(body)
 
         regk = (
             iserder.ked["ri"]
@@ -966,20 +1069,102 @@ class CredentialCollectionEnd:
             raise falcon.HTTPNotFound(
                 description=f"issue against invalid registry SAID {regk}"
             )
+        if regk not in agent.rgy.regs:
+            raise falcon.HTTPNotFound(
+                description=f"issue against uncontrolled registry SAID {regk}"
+            )
+        registry = agent.rgy.regs[regk]
+        if registry.hab.pre != hab.pre:
+            raise falcon.HTTPNotFound(
+                description=f"registry {regk} is not controlled by identifier {name}"
+            )
 
-        if hab.kever.estOnly:
-            op = self.identifierResource.rotate(agent, name, body)
-        else:
-            op = self.identifierResource.interact(agent, name, body)
+        tever = agent.rgy.tevers[regk]
+        credential_said = creder.said
+        issuance_credential_said = iserder.ked.get("i")
+        if issuance_credential_said != credential_said:
+            raise falcon.HTTPBadRequest(
+                description=(
+                    f"issuance event credential SAID {issuance_credential_said} does not match "
+                    f"acdc credential SAID {credential_said}"
+                )
+            )
+
+        groupCredential = isinstance(registry.hab, SignifyGroupHab)
+        if groupCredential:
+            _validateGroupTelAnchor(agent, registry.hab, iserder, anc)
+            existing = agent.monitor.opr.ops.get(
+                keys=(f"{longrunning.OpTypes.credential}.{credential_said}",)
+            )
+            if (
+                existing is not None
+                and existing.metadata.get("tel", {}).get("said") == iserder.said
+            ):
+                op = agent.monitor.get(
+                    f"{longrunning.OpTypes.credential}.{credential_said}"
+                )
+                rep.status = falcon.HTTP_202
+                rep.data = op.to_json().encode("utf-8")
+                return
+
+            if _telEventSaidProcessed(agent.rgy.reger, credential_said, iserder):
+                _startGroupKel(agent, registry.hab, anc, sigers)
+                agent.registrar.escrowGroupTel(regk, iserder, anc)
+                agent.credentialer.issue(creder=creder, serder=iserder)
+                op = _groupCredentialOperation(
+                    agent, credential_said, iserder, anc, creder
+                )
+                rep.status = falcon.HTTP_202
+                rep.data = op.to_json().encode("utf-8")
+                return
+
+        if tever.vcState(credential_said) is not None:
+            raise falcon.HTTPConflict(
+                description=f"credential {credential_said} is already issued in registry {regk}"
+            )
+
+        iss_sn = coring.Number(numh=iserder.ked["s"]).sn
+        credential_event_sn = tever.vcSn(credential_said)
+        expected_sn = 0 if credential_event_sn is None else credential_event_sn + 1
+        if iss_sn != expected_sn:
+            raise falcon.HTTPConflict(
+                description=(
+                    f"issuance event sequence {iss_sn} does not chain to current "
+                    f"TEL head for credential {credential_said}"
+                )
+            )
+
+        if _telEventSaidProcessed(agent.rgy.reger, credential_said, iserder):
+            raise falcon.HTTPConflict(
+                description=f"issuance event {iserder.said} has already been processed"
+            )
+        _validateTelAnchor(iserder, anc)
 
         try:
             agent.credentialer.validate(creder)
+        except kering.ConfigurationError as e:
+            rep.status = falcon.HTTP_400
+            rep.text = e.args[0]
+            return
+
+        if groupCredential:
+            _startGroupKel(agent, registry.hab, anc, sigers)
+            agent.credentialer.issue(creder=creder, serder=iserder)
+            agent.registrar.issue(regk, iserder, anc)
+            op = _groupCredentialOperation(agent, credential_said, iserder, anc, creder)
+            rep.status = falcon.HTTP_202
+            rep.data = op.to_json().encode("utf-8")
+            return
+
+        op = self.identifierResource.interact(agent, name, body)
+
+        try:
             agent.registrar.issue(regk, iserder, anc)
             agent.credentialer.issue(creder=creder, serder=iserder)
             op = agent.monitor.submit(
                 creder.said,
                 longrunning.OpTypes.credential,
-                metadata=dict(ced=creder.sad, depends=op),
+                metadata=dict(ced=creder.sad),
             )
 
         except kering.ConfigurationError as e:
@@ -1175,7 +1360,6 @@ class CredentialResourceDeleteEnd:
         RequestBody:
             rev (str): serialized revocation event
             ixn (str): serialized interaction event
-            rot (str): serialized rotation event
             sigs (list): list of signatures for the revocation event
         ---
         summary: Perform credential revocation
@@ -1207,10 +1391,7 @@ class CredentialResourceDeleteEnd:
                       description: Serialized revocation event.
                     ixn:
                       type: string
-                      description: Serialized interaction event.
-                    rot:
-                      type: string
-                      description: Serialized rotation event.
+                      description: Required serialized interaction event that anchors the revocation.
                     sigs:
                       type: array
                       items:
@@ -1227,6 +1408,8 @@ class CredentialResourceDeleteEnd:
                         - $ref: '#/components/schemas/DelegationOperation'
                         - $ref: '#/components/schemas/WitnessOperation'
                         - $ref: '#/components/schemas/DoneOperation'
+            202:
+                description: Group credential revocation accepted.
             400:
                 description: Bad request. This could be due to invalid revocation event or other invalid parameters.
             404:
@@ -1245,13 +1428,30 @@ class CredentialResourceDeleteEnd:
             raise falcon.HTTPNotFound(
                 description=f"{name} is not a valid reference to an identifier"
             )
+        if hab.kever.estOnly:
+            raise falcon.HTTPBadRequest(
+                description=(
+                    "credential revocation for establishment-only identifiers is not "
+                    "supported"
+                )
+            )
 
         rserder = serdering.SerderKERI(sad=httping.getRequiredParam(body, "rev"))
+        anc, sigers = _parseCredentialAnchor(body)
 
         regk = rserder.ked["ri"]
         if regk not in agent.rgy.tevers:
             raise falcon.HTTPNotFound(
                 description=f"revocation against invalid registry SAID {regk}"
+            )
+        if regk not in agent.rgy.regs:
+            raise falcon.HTTPNotFound(
+                description=f"revocation against uncontrolled registry SAID {regk}"
+            )
+        registry = agent.rgy.regs[regk]
+        if registry.hab.pre != hab.pre:
+            raise falcon.HTTPNotFound(
+                description=f"registry {regk} is not controlled by identifier {name}"
             )
 
         try:
@@ -1261,12 +1461,71 @@ class CredentialResourceDeleteEnd:
                 description=f"credential for said {said} not found."
             )
 
-        if hab.kever.estOnly:
-            op = self.identifierResource.rotate(agent, name, body)
-            anc = httping.getRequiredParam(body, "rot")
-        else:
-            op = self.identifierResource.interact(agent, name, body)
-            anc = httping.getRequiredParam(body, "ixn")
+        tever = agent.rgy.tevers[regk]
+        revocation_credential_said = rserder.ked.get("i")
+        if revocation_credential_said != said:
+            raise falcon.HTTPBadRequest(description="invalid revocation event.")
+
+        groupCredential = isinstance(registry.hab, SignifyGroupHab)
+        if groupCredential:
+            _validateGroupTelAnchor(agent, registry.hab, rserder, anc)
+            existing = agent.monitor.opr.ops.get(
+                keys=(f"{longrunning.OpTypes.credential}.{said}",)
+            )
+            if (
+                existing is not None
+                and existing.metadata.get("tel", {}).get("said") == rserder.said
+            ):
+                op = agent.monitor.get(f"{longrunning.OpTypes.credential}.{said}")
+                rep.status = falcon.HTTP_202
+                rep.data = op.to_json().encode("utf-8")
+                return
+
+            if _telEventSaidProcessed(agent.rgy.reger, said, rserder):
+                _startGroupKel(agent, registry.hab, anc, sigers)
+                agent.registrar.escrowGroupTel(regk, rserder, anc)
+                op = _groupCredentialOperation(agent, said, rserder, anc)
+                rep.status = falcon.HTTP_202
+                rep.data = op.to_json().encode("utf-8")
+                return
+
+        state = tever.vcState(said)
+        if state is None:
+            raise falcon.HTTPConflict(
+                description=f"credential {said} is not issued in registry {regk}"
+            )
+
+        if state.et in (coring.Ilks.rev, coring.Ilks.brv):
+            raise falcon.HTTPConflict(
+                description=f"credential {said} is already revoked in registry {regk}"
+            )
+
+        rev_sn = coring.Number(numh=rserder.ked["s"]).sn
+        credential_event_sn = tever.vcSn(said)
+        expected_sn = 0 if credential_event_sn is None else credential_event_sn + 1
+        if rev_sn != expected_sn:
+            raise falcon.HTTPConflict(
+                description=(
+                    f"revocation event sequence {rev_sn} does not chain to current "
+                    f"TEL head for credential {said}"
+                )
+            )
+
+        if _telEventSaidProcessed(agent.rgy.reger, said, rserder):
+            raise falcon.HTTPConflict(
+                description=f"revocation event {rserder.said} has already been processed"
+            )
+        _validateTelAnchor(rserder, anc)
+
+        if groupCredential:
+            _startGroupKel(agent, registry.hab, anc, sigers)
+            agent.registrar.revoke(regk, rserder, anc)
+            op = _groupCredentialOperation(agent, said, rserder, anc)
+            rep.status = falcon.HTTP_202
+            rep.data = op.to_json().encode("utf-8")
+            return
+
+        op = self.identifierResource.interact(agent, name, body)
 
         try:
             agent.registrar.revoke(regk, rserder, anc)
@@ -1279,7 +1538,7 @@ class CredentialResourceDeleteEnd:
 
 class CredentialRegistryResourceEnd:
     @staticmethod
-    def on_get(req, rep, ri, vci):
+    def on_get(req, rep, ri, credential_said):
         """Get credential registry state
 
         Parameters:
@@ -1300,7 +1559,7 @@ class CredentialRegistryResourceEnd:
              required: true
              description: SAID of management TEL
            - in: path
-             name: vci
+             name: credential_said
              schema:
                type: string
              required: true
@@ -1321,10 +1580,10 @@ class CredentialRegistryResourceEnd:
             raise falcon.HTTPNotFound(description=f"registry {ri} not found")
         tever = agent.tvy.tevers[ri]
 
-        state = tever.vcState(vci)
+        state = tever.vcState(credential_said)
         if not state:
             raise falcon.HTTPNotFound(
-                description=f"credential {vci} not found in registry {ri}"
+                description=f"credential {credential_said} not found in registry {ri}"
             )
 
         rep.status = falcon.HTTP_200
@@ -1452,23 +1711,7 @@ class Registrar:
             return vcid, rseq.sn
 
         else:  # multisig group hab
-            sn = anc.sn
-            said = anc.said
-
-            prefixer = coring.Prefixer(qb64=hab.pre)
-            seqner = coring.Seqner(sn=sn)
-            saider = coring.Saider(qb64=said)
-
-            logger.info(
-                "[%s | %s]: Waiting for TEL iss event mulisig anchoring event %s",
-                hab.name,
-                hab.pre,
-                seqner.sn,
-            )
-            self.rgy.reger.tmse.add(
-                keys=(vcid, rseq.qb64, iserder.said), val=(prefixer, seqner, saider)
-            )
-            return vcid, rseq.sn
+            return self.escrowGroupTel(regk, iserder, anc)
 
     def revoke(self, regk, rserder, anc):
         """
@@ -1503,28 +1746,34 @@ class Registrar:
             )
             return vcid, rseq.sn
         else:
-            serder = serdering.SerderKERI(sad=anc)
-            sn = serder.sn
-            said = serder.said
+            return self.escrowGroupTel(regk, rserder, anc)
 
-            prefixer = coring.Prefixer(qb64=hab.pre)
-            seqner = coring.Seqner(sn=sn)
-            saider = coring.Saider(qb64=said)
-
-            self.counselor.start(
-                prefixer=prefixer, seqner=seqner, saider=saider, ghab=hab
+    def escrowGroupTel(self, regk, serder, anc):
+        """Ensure the multisig escrow exists for a processed TEL event."""
+        registry = self.rgy.regs[regk]
+        hab = registry.hab
+        if not isinstance(hab, SignifyGroupHab):
+            raise kering.ConfigurationError(
+                f"registry {regk} is not controlled by a group identifier"
             )
 
-            logger.info(
-                "[%s | %s]: Waiting for TEL rev event mulisig anchoring event %s",
-                hab.name,
-                hab.pre,
-                seqner.sn,
-            )
-            self.rgy.reger.tmse.add(
-                keys=(vcid, rseq.qb64, rserder.said), val=(prefixer, seqner, saider)
-            )
-            return vcid, rseq.sn
+        vcid = serder.ked["i"]
+        rseq = coring.Seqner(snh=serder.ked["s"])
+        prefixer = coring.Prefixer(qb64=hab.pre)
+        seqner = coring.Seqner(sn=anc.sn)
+        saider = coring.Saider(qb64=anc.said)
+
+        logger.info(
+            "[%s | %s]: Waiting for TEL %s event multisig anchoring event %s",
+            hab.name,
+            hab.pre,
+            serder.ilk,
+            seqner.sn,
+        )
+        self.rgy.reger.tmse.add(
+            keys=(vcid, rseq.qb64, serder.said), val=(prefixer, seqner, saider)
+        )
+        return vcid, rseq.sn
 
     def complete(self, pre, sn=0):
         """Determine if registry event (inception, issuance, revocation, etc.) is finished validation

--- a/src/keria/core/longrunning.py
+++ b/src/keria/core/longrunning.py
@@ -471,13 +471,54 @@ class Monitor:
                 done = False
 
         elif op.type in (OpTypes.credential,):
-            if "ced" not in op.metadata:
+            if "ced" not in op.metadata and "credential_said" not in op.metadata:
                 raise kering.ValidationError(
-                    f"invalid long running {op.type} operation, metadata missing 'ced' field"
+                    f"invalid long running {op.type} operation, metadata missing 'ced' or 'credential_said' field"
                 )
 
-            ced = op.metadata["ced"]
-            if self.credentialer.complete(ced["d"]):
+            credential_said = op.metadata.get("credential_said")
+            ced = op.metadata.get("ced")
+            if ced is not None:
+                credential_said = ced["d"]
+
+            group = op.metadata.get("group")
+            tel = op.metadata.get("tel")
+            if group is not None:
+                required = ("pre", "sn", "said")
+                if any(field not in group for field in required):
+                    raise kering.ValidationError(
+                        "invalid long running credential operation, group metadata missing required fields "
+                        "('pre', 'sn', 'said')"
+                    )
+                if tel is None or "sn" not in tel:
+                    raise kering.ValidationError(
+                        "invalid long running credential operation, group credential metadata missing TEL sequence"
+                    )
+
+                prefixer = coring.Prefixer(qb64=group["pre"])
+                seqner = coring.Seqner(sn=group["sn"])
+                saider = coring.Saider(qb64=group["said"])
+                if not self.counselor.complete(prefixer, seqner, saider):
+                    metadata = dict(**op.metadata, state="kel-pending")
+                    done = False
+                elif not self.registrar.complete(pre=credential_said, sn=tel["sn"]):
+                    metadata = dict(**op.metadata, state="tel-pending")
+                    done = False
+                elif ced is None:
+                    done = True
+                    metadata = dict(**op.metadata, state="completed")
+                    response = dict(credential_said=credential_said)
+                elif self.credentialer.complete(credential_said):
+                    done = True
+                    metadata = dict(**op.metadata, state="completed")
+                    response = dict(ced=ced)
+                else:
+                    metadata = dict(**op.metadata, state="credential-pending")
+                    done = False
+            elif ced is None:
+                done = True
+                response = dict(credential_said=credential_said)
+            elif self.credentialer.complete(credential_said):
                 done = True
                 response = dict(ced=ced)
             else:

--- a/tests/app/test_credentialing.py
+++ b/tests/app/test_credentialing.py
@@ -886,50 +886,33 @@ def _setup_credential_issue_routes(app, idResEnd):
     app.add_route("/registries/{ri}/{credential_said}", credentialRegistryResEnd)
 
 
-def _create_group(client, helpers, doist, deeds):
-    memberSalts = [b"0123456789abcM00", b"0123456789abcM01"]
-    signers = []
-    for index, salt in enumerate(memberSalts):
-        helpers.createAid(client, f"member{index}", salt)
-        _, signer = helpers.incept(salt, "signify:aid", pidx=0)
-        signers.append(signer[0])
+def _create_group_member(client, helpers, name, salt):
+    helpers.createAid(client, name, salt)
+    member = client.simulate_get(f"/identifiers/{name}").json
+    _, signers = helpers.incept(salt, "signify:aid", pidx=0)
+    return member, signers[0]
 
-    memberRecords = [
-        client.simulate_get(f"/identifiers/member{index}").json
-        for index in range(len(memberSalts))
-    ]
-    memberStates = [member["state"] for member in memberRecords]
-    keys = [state["k"][0] for state in memberStates]
-    ndigs = [state["n"][0] for state in memberStates]
-    groupIcp = keventing.incept(
-        keys=keys,
-        isith="2",
-        nsith="2",
-        ndigs=ndigs,
-        code=coring.MtrDex.Blake3_256,
-        toad=0,
-        wits=[],
+
+def _share_identifier(source, target, name):
+    target.parser.parse(ims=source.hby.habByName(name).replay())
+
+
+def _join_group(client, member, members, group_icp, group_sigs, keys, ndigs):
+    prefixes = [record["prefix"] for record in members]
+    result = client.simulate_post(
+        "/identifiers",
+        body=json.dumps(
+            dict(
+                name="group",
+                icp=group_icp.ked,
+                sigs=group_sigs,
+                smids=prefixes,
+                rmids=prefixes,
+                group=dict(mhab=member, keys=keys, ndigs=ndigs),
+            )
+        ),
     )
-    groupSigs = [
-        signer.sign(ser=groupIcp.raw, index=index).qb64
-        for index, signer in enumerate(signers)
-    ]
-    memberPrefixes = [state["i"] for state in memberStates]
-    body = dict(
-        name="group",
-        icp=groupIcp.ked,
-        sigs=groupSigs,
-        smids=memberPrefixes,
-        rmids=memberPrefixes,
-        group=dict(mhab=memberRecords[0], keys=keys, ndigs=ndigs),
-    )
-    result = client.simulate_post("/identifiers", body=json.dumps(body))
     assert result.status_code == 202
-
-    for _ in range(5):
-        doist.recur(deeds=deeds)
-
-    return groupIcp.pre, signers
 
 
 def _group_interaction(ghab, signers, data):
@@ -944,6 +927,71 @@ def _group_interaction(ghab, signers, data):
         for index, signer in enumerate(signers)
     ]
     return serder, sigs
+
+
+def _run_until(doist, deeds, predicate):
+    for _ in range(100):
+        doist.recur(deeds=deeds)
+        if predicate():
+            return
+    assert predicate()
+
+
+def _create_group_registry(client, ghab, signers, agent, doist, deeds, registry=None):
+    if registry is None:
+        registry = eventing.incept(
+            ghab.pre,
+            baks=[],
+            toad="0",
+            nonce=Salter().qb64,
+            cnfg=[TraitCodex.NoBackers],
+            code=coring.MtrDex.Blake3_256,
+        )
+    anchor = dict(i=registry.ked["i"], s=registry.ked["s"], d=registry.said)
+    kel, sigs = _group_interaction(ghab, signers, [anchor])
+    result = client.simulate_post(
+        "/identifiers/group/registries",
+        body=json.dumps(
+            dict(
+                name="group-registry",
+                vcp=registry.ked,
+                ixn=kel.ked,
+                sigs=sigs,
+                group={},
+            )
+        ),
+    )
+    assert result.status_code == 202
+    _run_until(doist, deeds, lambda: registry.pre in agent.tvy.tevers)
+    return registry
+
+
+def _build_group_issuance(ghab, signers, registry, recipient, lei):
+    dt = "2021-01-01T00:00:00.000000+00:00"
+    credential = proving.credential(
+        issuer=ghab.pre,
+        schema="EFgnk_c08WmZGgv9_mpldibRuqFMTQN-rAgtD-TCOwbs",
+        recipient=recipient,
+        data=dict(LEI=lei, dt=dt),
+        source={},
+        status=registry.pre,
+    )
+    tel, kel, body = _build_group_credential_request(
+        ghab, signers, registry, credential
+    )
+    return credential, tel, kel, body
+
+
+def _build_group_credential_request(ghab, signers, registry, credential):
+    tel = eventing.issue(
+        vcdig=credential.said,
+        regk=registry.pre,
+        dt=credential.sad["a"]["dt"],
+    )
+    anchor = dict(i=tel.ked["i"], s=tel.ked["s"], d=tel.said)
+    kel, sigs = _group_interaction(ghab, signers, [anchor])
+    body = dict(acdc=credential.sad, iss=tel.ked, ixn=kel.ked, sigs=sigs, group={})
+    return tel, kel, body
 
 
 def _build_issuance_body(
@@ -1302,146 +1350,163 @@ def test_duplicate_revocation_rejection(helpers, seeder):
         assert res.json["et"] == "rev"
 
 
-def test_group_credential_uses_durable_kel_and_tel_escrows(
-    helpers, seeder, monkeypatch
-):
-    with helpers.openKeria() as (agency, agent, app, client):
-        idResEnd = aiding.IdentifierResourceEnd()
-        _setup_credential_issue_routes(app, idResEnd)
-        seeder.seedSchema(agent.hby.db)
+def test_second_member_retry_does_not_block_in_flight_credential(helpers, seeder):
+    with (
+        helpers.openKeria(salter=Salter(raw=b"0123456789abcM01")) as (
+            _,
+            agent_one,
+            app_one,
+            client_one,
+        ),
+        helpers.openKeria(salter=Salter(raw=b"0123456789abcM02")) as (
+            _,
+            agent_two,
+            app_two,
+            client_two,
+        ),
+    ):
+        for app in (app_one, app_two):
+            _setup_credential_issue_routes(app, aiding.IdentifierResourceEnd())
+        for agent in (agent_one, agent_two):
+            seeder.seedSchema(agent.hby.db)
 
-        serverDoer = helpers.server(agency)
         doist = doing.Doist(limit=1.0, tock=0.03125, real=True)
-        deeds = doist.enter(doers=[agent, serverDoer])
+        deeds = doist.enter(doers=[agent_one, agent_two])
 
-        groupPre, signers = _create_group(client, helpers, doist, deeds)
-        ghab = agent.hby.habByName("group")
-        assert isinstance(ghab, SignifyGroupHab)
+        member_one, signer_one = _create_group_member(
+            client_one, helpers, "member-one", b"0123456789abcM11"
+        )
+        member_two, signer_two = _create_group_member(
+            client_two, helpers, "member-two", b"0123456789abcM12"
+        )
+        _share_identifier(agent_one, agent_two, "member-one")
+        _share_identifier(agent_two, agent_one, "member-two")
 
-        regser = eventing.incept(
-            groupPre,
-            baks=[],
-            toad="0",
-            nonce=Salter().qb64,
-            cnfg=[TraitCodex.NoBackers],
+        members = [member_one, member_two]
+        keys = [member["state"]["k"][0] for member in members]
+        ndigs = [member["state"]["n"][0] for member in members]
+        group_icp = keventing.incept(
+            keys=keys,
+            isith="2",
+            nsith="2",
+            ndigs=ndigs,
             code=coring.MtrDex.Blake3_256,
+            toad=0,
+            wits=[],
         )
-        registryAnchor = dict(i=regser.ked["i"], s=regser.ked["s"], d=regser.said)
-        registryKel, registrySigs = _group_interaction(ghab, signers, [registryAnchor])
-        registryBody = dict(
-            name="group-registry",
-            vcp=regser.ked,
-            ixn=registryKel.ked,
-            sigs=registrySigs,
-            group={},
+        signers = [signer_one, signer_two]
+        group_sigs = [
+            signer.sign(ser=group_icp.raw, index=index).qb64
+            for index, signer in enumerate(signers)
+        ]
+        _join_group(client_one, member_one, members, group_icp, group_sigs, keys, ndigs)
+        _join_group(client_two, member_two, members, group_icp, group_sigs, keys, ndigs)
+        ghab_one = agent_one.hby.habByName("group")
+        ghab_two = agent_two.hby.habByName("group")
+        assert isinstance(ghab_one, SignifyGroupHab)
+        assert isinstance(ghab_two, SignifyGroupHab)
+
+        registry = _create_group_registry(
+            client_one, ghab_one, signers, agent_one, doist, deeds
         )
-        result = client.simulate_post(
-            "/identifiers/group/registries", body=json.dumps(registryBody)
+        _share_identifier(agent_one, agent_two, "group")
+        _create_group_registry(
+            client_two, ghab_two, signers, agent_two, doist, deeds, registry
+        )
+
+        holder_one = helpers.createAid(client_one, "holder-one", b"0123456789abcM13")[
+            "response"
+        ]["i"]
+        holder_two = helpers.createAid(client_one, "holder-two", b"0123456789abcM14")[
+            "response"
+        ]["i"]
+
+        credential_one, _, _, issue_one = _build_group_issuance(
+            ghab_one, signers, registry, holder_one, "254900DA0GOGCFVWB618"
+        )
+        result = client_one.simulate_post(
+            "/identifiers/group/credentials", body=json.dumps(issue_one)
         )
         assert result.status_code == 202
-
-        for _ in range(100):
-            doist.recur(deeds=deeds)
-            if regser.pre in agent.tvy.tevers:
-                break
-        assert regser.pre in agent.tvy.tevers
-
-        counselor_starts = []
-        start = agent.counselor.start
-
-        def record_start(*args, **kwargs):
-            counselor_starts.append(kwargs["saider"].qb64)
-            return start(*args, **kwargs)
-
-        monkeypatch.setattr(agent.counselor, "start", record_start)
-
-        recipient = client.simulate_get("/identifiers/member0").json["prefix"]
-        creder = proving.credential(
-            issuer=groupPre,
-            schema="EFgnk_c08WmZGgv9_mpldibRuqFMTQN-rAgtD-TCOwbs",
-            recipient=recipient,
-            data=dict(
-                LEI="254900DA0GOGCFVWB618", dt="2021-01-01T00:00:00.000000+00:00"
-            ),
-            source={},
-            status=regser.pre,
+        issue_one_op = result.json
+        _run_until(
+            doist,
+            deeds,
+            lambda: agent_one.credentialer.complete(credential_one.said),
         )
-        iserder = eventing.issue(
-            vcdig=creder.said,
-            regk=regser.pre,
-            dt="2021-01-01T00:00:00.000000+00:00",
+
+        # M2 accepts credential 1 from its ACDC, not M1's original request.
+        _share_identifier(agent_one, agent_two, "group")
+        _, _, accept_one = _build_group_credential_request(
+            ghab_two, signers, registry, credential_one
         )
-        issueAnchor = dict(i=iserder.ked["i"], s=iserder.ked["s"], d=iserder.said)
-        issueKel, issueSigs = _group_interaction(ghab, signers, [issueAnchor])
-        issueBody = dict(
-            acdc=creder.sad,
-            iss=iserder.ked,
-            ixn=issueKel.ked,
-            sigs=issueSigs,
-            group={},
-        )
-        result = client.simulate_post(
-            "/identifiers/group/credentials", body=json.dumps(issueBody)
+        result = client_two.simulate_post(
+            "/identifiers/group/credentials", body=json.dumps(accept_one)
         )
         assert result.status_code == 202
-        issueOp = result.json
-        assert issueOp["name"] == f"credential.{creder.said}"
-        assert issueOp["metadata"]["group"]["said"] == issueKel.said
-        assert issueOp["metadata"]["tel"]["said"] == iserder.said
-
-        retry = client.simulate_post(
-            "/identifiers/group/credentials", body=json.dumps(issueBody)
+        accept_one_op = result.json
+        _run_until(
+            doist,
+            deeds,
+            lambda: agent_two.credentialer.complete(credential_one.said),
         )
-        assert retry.status_code == 202
-        assert retry.json["name"] == issueOp["name"]
+        for client, op in (
+            (client_one, issue_one_op),
+            (client_two, accept_one_op),
+        ):
+            result = client.simulate_get(f"/operations/{op['name']}")
+            assert result.status_code == 200
+            assert result.json["done"]
+            result = client.simulate_get(f"/credentials/{credential_one.said}")
+            assert result.status_code == 200
+            assert result.json["iss"]
 
-        for _ in range(100):
-            doist.recur(deeds=deeds)
-            if agent.credentialer.complete(creder.said):
-                break
-        assert agent.credentialer.complete(creder.said)
-        assert client.simulate_get(f"/operations/{issueOp['name']}").json["done"]
-
-        rserder = eventing.revoke(
-            vcdig=creder.said,
-            regk=regser.pre,
-            dig=iserder.said,
-            dt="2021-01-01T00:00:00.000000+00:00",
+        # M1 starts credential 2, but M2 has not yet accepted its exchange.
+        _share_identifier(agent_two, agent_one, "group")
+        credential_two, _, _, issue_two = _build_group_issuance(
+            ghab_one, signers, registry, holder_two, "9845004CC7884BN85018"
         )
-        revokeAnchor = dict(i=rserder.ked["i"], s=rserder.ked["s"], d=rserder.said)
-        revokeKel, revokeSigs = _group_interaction(ghab, signers, [revokeAnchor])
-        revokeBody = dict(
-            rev=rserder.ked,
-            ixn=revokeKel.ked,
-            sigs=revokeSigs,
-            group={},
-        )
-        # Simulate an interrupted request after the TEL was persisted but before
-        # Registrar.revoke could enqueue its multisig escrow.
-        agent.rgy.regs[regser.pre].processEvent(serder=rserder)
-        assert credentialing._telEventSaidProcessed(
-            agent.rgy.reger, creder.said, rserder
-        )
-        assert not agent.registrar.complete(creder.said, sn=1)
-
-        result = client.simulate_delete(
-            f"/identifiers/group/credentials/{creder.said}",
-            body=json.dumps(revokeBody),
+        result = client_one.simulate_post(
+            "/identifiers/group/credentials", body=json.dumps(issue_two)
         )
         assert result.status_code == 202
-        revokeOp = result.json
+        issue_two_op = result.json
+        assert not agent_two.credentialer.complete(credential_two.said)
 
-        retry = client.simulate_delete(
-            f"/identifiers/group/credentials/{creder.said}",
-            body=json.dumps(revokeBody),
+        # A stale credential-1 acceptance must be idempotent and leave M2 able
+        # to accept the credential-2 exchange afterwards.
+        _, _, stale_accept = _build_group_credential_request(
+            ghab_two, signers, registry, credential_one
         )
-        assert retry.status_code == 202
-        assert retry.json["name"] == revokeOp["name"]
+        result = client_two.simulate_post(
+            "/identifiers/group/credentials", body=json.dumps(stale_accept)
+        )
+        assert result.status_code == 202
+        assert result.json["done"]
 
-        for _ in range(100):
-            doist.recur(deeds=deeds)
-            if agent.registrar.complete(creder.said, sn=1):
-                break
-        assert agent.registrar.complete(creder.said, sn=1)
-        assert client.simulate_get(f"/operations/{revokeOp['name']}").json["done"]
-        assert counselor_starts == [issueKel.said, revokeKel.said]
+        _share_identifier(agent_one, agent_two, "group")
+        _, _, accept_two = _build_group_credential_request(
+            ghab_two, signers, registry, credential_two
+        )
+        result = client_two.simulate_post(
+            "/identifiers/group/credentials", body=json.dumps(accept_two)
+        )
+        assert result.status_code == 202
+        accept_two_op = result.json
+        _run_until(
+            doist,
+            deeds,
+            lambda: agent_one.credentialer.complete(credential_two.said)
+            and agent_two.credentialer.complete(credential_two.said),
+        )
+
+        for client, op in (
+            (client_one, issue_two_op),
+            (client_two, accept_two_op),
+        ):
+            result = client.simulate_get(f"/operations/{op['name']}")
+            assert result.status_code == 200
+            assert result.json["done"]
+            result = client.simulate_get(f"/credentials/{credential_two.said}")
+            assert result.status_code == 200
+            assert result.json["iss"]

--- a/tests/app/test_credentialing.py
+++ b/tests/app/test_credentialing.py
@@ -12,7 +12,9 @@ import falcon
 from falcon import testing
 from hio.base import doing
 from keri.app import habbing
-from keri.core import scheming, coring, parsing, serdering
+from keri.app.habbing import SignifyGroupHab
+from keri.core import eventing as keventing, scheming, coring, parsing, serdering
+from keri.db import dbing
 from keri.core.eventing import SealEvent
 from keri.core.signing import Salter
 from keri.kering import TraitCodex
@@ -444,7 +446,7 @@ def test_credentialing_ends(helpers, seeder):
         credResEnd = credentialing.CredentialResourceEnd()
         app.add_route("/credentials/{said}", credResEnd)
         credentialRegistryResEnd = credentialing.CredentialRegistryResourceEnd()
-        app.add_route("/registries/{ri}/{vci}", credentialRegistryResEnd)
+        app.add_route("/registries/{ri}/{credential_said}", credentialRegistryResEnd)
 
         assert hab.pre == "EIqTaQiZw73plMOq8pqHTi9BDgDrrE7iE9v2XfN2Izze"
 
@@ -682,7 +684,7 @@ def test_revoke_credential(helpers, seeder):
         credResEnd = credentialing.CredentialQueryCollectionEnd()
         app.add_route("/credentials/query", credResEnd)
         credentialRegistryResEnd = credentialing.CredentialRegistryResourceEnd()
-        app.add_route("/registries/{ri}/{vci}", credentialRegistryResEnd)
+        app.add_route("/registries/{ri}/{credential_said}", credentialRegistryResEnd)
 
         seeder.seedSchema(agent.hby.db)
 
@@ -862,3 +864,584 @@ def test_revoke_credential(helpers, seeder):
         assert res.status_code == 200
         assert res.json["s"] == "1"
         assert res.json["et"] == "rev"
+
+
+def _setup_credential_issue_routes(app, idResEnd):
+    app.add_route("/identifiers/{name}", idResEnd)
+    registryEnd = credentialing.RegistryCollectionEnd(idResEnd)
+    app.add_route("/identifiers/{name}/registries", registryEnd)
+    credEnd = credentialing.CredentialCollectionEnd(idResEnd)
+    app.add_route("/identifiers/{name}/credentials", credEnd)
+    opEnd = longrunning.OperationResourceEnd()
+    app.add_route("/operations/{name}", opEnd)
+    end = aiding.IdentifierCollectionEnd()
+    app.add_route("/identifiers", end)
+    endRolesEnd = aiding.EndRoleCollectionEnd()
+    app.add_route("/identifiers/{name}/endroles", endRolesEnd)
+    credResEnd = credentialing.CredentialResourceEnd()
+    app.add_route("/credentials/{said}", credResEnd)
+    credResDelEnd = credentialing.CredentialResourceDeleteEnd(idResEnd)
+    app.add_route("/identifiers/{name}/credentials/{said}", credResDelEnd)
+    credentialRegistryResEnd = credentialing.CredentialRegistryResourceEnd()
+    app.add_route("/registries/{ri}/{credential_said}", credentialRegistryResEnd)
+
+
+def _create_group(client, helpers, doist, deeds):
+    memberSalts = [b"0123456789abcM00", b"0123456789abcM01"]
+    signers = []
+    for index, salt in enumerate(memberSalts):
+        helpers.createAid(client, f"member{index}", salt)
+        _, signer = helpers.incept(salt, "signify:aid", pidx=0)
+        signers.append(signer[0])
+
+    memberRecords = [
+        client.simulate_get(f"/identifiers/member{index}").json
+        for index in range(len(memberSalts))
+    ]
+    memberStates = [member["state"] for member in memberRecords]
+    keys = [state["k"][0] for state in memberStates]
+    ndigs = [state["n"][0] for state in memberStates]
+    groupIcp = keventing.incept(
+        keys=keys,
+        isith="2",
+        nsith="2",
+        ndigs=ndigs,
+        code=coring.MtrDex.Blake3_256,
+        toad=0,
+        wits=[],
+    )
+    groupSigs = [
+        signer.sign(ser=groupIcp.raw, index=index).qb64
+        for index, signer in enumerate(signers)
+    ]
+    memberPrefixes = [state["i"] for state in memberStates]
+    body = dict(
+        name="group",
+        icp=groupIcp.ked,
+        sigs=groupSigs,
+        smids=memberPrefixes,
+        rmids=memberPrefixes,
+        group=dict(mhab=memberRecords[0], keys=keys, ndigs=ndigs),
+    )
+    result = client.simulate_post("/identifiers", body=json.dumps(body))
+    assert result.status_code == 202
+
+    for _ in range(5):
+        doist.recur(deeds=deeds)
+
+    return groupIcp.pre, signers
+
+
+def _group_interaction(ghab, signers, data):
+    serder = keventing.interact(
+        pre=ghab.pre,
+        dig=ghab.kever.serder.said,
+        sn=ghab.kever.sn + 1,
+        data=data,
+    )
+    sigs = [
+        signer.sign(ser=serder.raw, index=index).qb64
+        for index, signer in enumerate(signers)
+    ]
+    return serder, sigs
+
+
+def _build_issuance_body(
+    helpers, registry, iaid, idig, isalt, recp, lei, sn, dig, dt, schema
+):
+    data = dict(LEI=lei, dt=dt)
+    creder = proving.credential(
+        issuer=iaid,
+        schema=schema,
+        recipient=recp,
+        data=data,
+        source={},
+        status=registry["regk"],
+    )
+    csigers = helpers.sign(bran=isalt, pidx=0, ridx=0, ser=creder.raw)
+    regser = eventing.issue(vcdig=creder.said, regk=registry["regk"], dt=dt)
+    anchor = dict(i=regser.ked["i"], s=regser.ked["s"], d=regser.said)
+    serder, sigers = helpers.interact(
+        pre=iaid, bran=isalt, pidx=0, ridx=0, dig=dig, sn=sn, data=[anchor]
+    )
+    pather = coring.Pather(path=[])
+    body = dict(
+        iss=regser.ked,
+        ixn=serder.ked,
+        sigs=sigers,
+        acdc=creder.sad,
+        csigs=csigers,
+        path=pather.qb64,
+    )
+    return creder, body, serder
+
+
+def test_duplicate_issuance_rejection(helpers, seeder):
+    with helpers.openKeria() as (agency, agent, app, client):
+        idResEnd = aiding.IdentifierResourceEnd()
+        _setup_credential_issue_routes(app, idResEnd)
+        seeder.seedSchema(agent.hby.db)
+
+        serverDoer = helpers.server(agency)
+        tock = 0.03125
+        limit = 1.0
+        doist = doing.Doist(limit=limit, tock=tock, real=True)
+        deeds = doist.enter(doers=[agent, serverDoer])
+
+        isalt = b"0123456789abcdef"
+        registry, issuer = helpers.createRegistry(client, agent, isalt, doist, deeds)
+        iaid = issuer["prefix"]
+        idig = issuer["state"]["d"]
+
+        rsalt = b"abcdef0123456789"
+        op = helpers.createAid(client, "recipient", rsalt)
+        recp = op["response"]["i"]
+        helpers.createEndRole(client, agent, recp, "recipient", rsalt)
+
+        dt = "2021-01-01T00:00:00.000000+00:00"
+        schema = "EFgnk_c08WmZGgv9_mpldibRuqFMTQN-rAgtD-TCOwbs"
+        creder, body, _ = _build_issuance_body(
+            helpers,
+            registry,
+            iaid,
+            idig,
+            isalt,
+            recp,
+            "254900DA0GOGCFVWB618",
+            "2",
+            idig,
+            dt,
+            schema,
+        )
+        issuance_body = json.dumps(body).encode("utf-8")
+
+        result = client.simulate_post(
+            path="/identifiers/issuer/credentials", body=issuance_body
+        )
+        assert result.status_code == 200
+
+        while not agent.credentialer.complete(creder.said):
+            doist.recur(deeds=deeds)
+
+        res = client.simulate_get(f"/credentials/{creder.said}")
+        assert res.status_code == 200
+
+        result = client.simulate_post(
+            path="/identifiers/issuer/credentials", body=issuance_body
+        )
+        assert result.status_code == 409
+        assert "already issued" in result.json["description"]
+
+        res = client.simulate_get(f"/credentials/{creder.said}")
+        assert res.status_code == 200
+
+
+def test_issuance_rejects_stale_and_persisted_tel_events(helpers, seeder):
+    with helpers.openKeria() as (agency, agent, app, client):
+        idResEnd = aiding.IdentifierResourceEnd()
+        _setup_credential_issue_routes(app, idResEnd)
+        seeder.seedSchema(agent.hby.db)
+
+        serverDoer = helpers.server(agency)
+        doist = doing.Doist(limit=1.0, tock=0.03125, real=True)
+        deeds = doist.enter(doers=[agent, serverDoer])
+
+        salt = b"0123456789abcdef"
+        registry, issuer = helpers.createRegistry(client, agent, salt, doist, deeds)
+        iaid = issuer["prefix"]
+        idig = issuer["state"]["d"]
+        creder, body, _ = _build_issuance_body(
+            helpers,
+            registry,
+            iaid,
+            idig,
+            salt,
+            iaid,
+            "254900DA0GOGCFVWB618",
+            "2",
+            idig,
+            "2021-01-01T00:00:00.000000+00:00",
+            "EFgnk_c08WmZGgv9_mpldibRuqFMTQN-rAgtD-TCOwbs",
+        )
+
+        staleKed = dict(body["iss"], s="1", d="")
+        stale = serdering.SerderKERI(sad=staleKed, makify=True)
+        staleBody = dict(body, iss=stale.ked)
+        result = client.simulate_post(
+            "/identifiers/issuer/credentials", body=json.dumps(staleBody)
+        )
+        assert result.status_code == 409
+        assert "does not chain to current TEL head" in result.json["description"]
+
+        iserder = serdering.SerderKERI(sad=body["iss"])
+        assert agent.rgy.reger.putTvt(
+            dbing.dgKey(creder.said, iserder.said), iserder.raw
+        )
+        result = client.simulate_post(
+            "/identifiers/issuer/credentials", body=json.dumps(body)
+        )
+        assert result.status_code == 409
+        assert "has already been processed" in result.json["description"]
+
+
+def test_credential_issuance_requires_interaction_anchor(helpers, seeder):
+    with helpers.openKeria() as (agency, agent, app, client):
+        idResEnd = aiding.IdentifierResourceEnd()
+        _setup_credential_issue_routes(app, idResEnd)
+        seeder.seedSchema(agent.hby.db)
+
+        serverDoer = helpers.server(agency)
+        doist = doing.Doist(limit=1.0, tock=0.03125, real=True)
+        deeds = doist.enter(doers=[agent, serverDoer])
+
+        salt = b"0123456789abcdef"
+        registry, issuer = helpers.createRegistry(client, agent, salt, doist, deeds)
+        iaid = issuer["prefix"]
+        idig = issuer["state"]["d"]
+        creder, body, _ = _build_issuance_body(
+            helpers,
+            registry,
+            iaid,
+            idig,
+            salt,
+            iaid,
+            "254900DA0GOGCFVWB618",
+            "2",
+            idig,
+            "2021-01-01T00:00:00.000000+00:00",
+            "EFgnk_c08WmZGgv9_mpldibRuqFMTQN-rAgtD-TCOwbs",
+        )
+        issuer_hab = agent.hby.habByName("issuer")
+        kel_sn = issuer_hab.kever.sn
+
+        without_anchor = dict(body)
+        without_anchor.pop("ixn")
+        rotation_anchor = dict(body)
+        rotation_anchor["rot"] = rotation_anchor.pop("ixn")
+        both_anchors = dict(body, rot=body["ixn"])
+
+        for payload, description in (
+            (without_anchor, "require an interaction anchor"),
+            (rotation_anchor, "only support interaction anchors"),
+            (both_anchors, "only support interaction anchors"),
+        ):
+            result = client.simulate_post(
+                "/identifiers/issuer/credentials", body=json.dumps(payload)
+            )
+            assert result.status_code == 400
+            assert description in result.json["description"]
+            assert issuer_hab.kever.sn == kel_sn
+            assert agent.rgy.tevers[registry["regk"]].vcState(creder.said) is None
+
+
+def test_duplicate_issuance_rejection_registry_advanced(helpers, seeder):
+    with helpers.openKeria() as (agency, agent, app, client):
+        idResEnd = aiding.IdentifierResourceEnd()
+        _setup_credential_issue_routes(app, idResEnd)
+        seeder.seedSchema(agent.hby.db)
+
+        serverDoer = helpers.server(agency)
+        tock = 0.03125
+        limit = 1.0
+        doist = doing.Doist(limit=limit, tock=tock, real=True)
+        deeds = doist.enter(doers=[agent, serverDoer])
+
+        isalt = b"0123456789abcdef"
+        registry, issuer = helpers.createRegistry(client, agent, isalt, doist, deeds)
+        iaid = issuer["prefix"]
+        idig = issuer["state"]["d"]
+
+        rsalt = b"abcdef0123456789"
+        op = helpers.createAid(client, "recipient", rsalt)
+        recp = op["response"]["i"]
+        helpers.createEndRole(client, agent, recp, "recipient", rsalt)
+
+        dt = "2021-01-01T00:00:00.000000+00:00"
+        schema = "EFgnk_c08WmZGgv9_mpldibRuqFMTQN-rAgtD-TCOwbs"
+        creder_a, body_a, ixn_a = _build_issuance_body(
+            helpers,
+            registry,
+            iaid,
+            idig,
+            isalt,
+            recp,
+            "254900DA0GOGCFVWB618",
+            "2",
+            idig,
+            dt,
+            schema,
+        )
+        issuance_body_a = json.dumps(body_a).encode("utf-8")
+        result = client.simulate_post(
+            path="/identifiers/issuer/credentials", body=issuance_body_a
+        )
+        assert result.status_code == 200
+
+        while not agent.credentialer.complete(creder_a.said):
+            doist.recur(deeds=deeds)
+
+        res = client.simulate_get(f"/credentials/{creder_a.said}")
+        assert res.status_code == 200
+
+        creder_b, body_b, _ = _build_issuance_body(
+            helpers,
+            registry,
+            iaid,
+            idig,
+            isalt,
+            recp,
+            "9845004CC7884BN85018",
+            "3",
+            ixn_a.said,
+            dt,
+            schema,
+        )
+        result = client.simulate_post(
+            path="/identifiers/issuer/credentials",
+            body=json.dumps(body_b).encode("utf-8"),
+        )
+        assert result.status_code == 200
+
+        while not agent.credentialer.complete(creder_b.said):
+            doist.recur(deeds=deeds)
+
+        result = client.simulate_post(
+            path="/identifiers/issuer/credentials", body=issuance_body_a
+        )
+        assert result.status_code == 409
+        assert "already issued" in result.json["description"]
+
+        res = client.simulate_get(f"/credentials/{creder_a.said}")
+        assert res.status_code == 200
+
+        res = client.simulate_get(f"/credentials/{creder_b.said}")
+        assert res.status_code == 200
+
+
+def test_duplicate_revocation_rejection(helpers, seeder):
+    with helpers.openKeria() as (agency, agent, app, client):
+        idResEnd = aiding.IdentifierResourceEnd()
+        _setup_credential_issue_routes(app, idResEnd)
+        seeder.seedSchema(agent.hby.db)
+
+        serverDoer = helpers.server(agency)
+        tock = 0.03125
+        limit = 1.0
+        doist = doing.Doist(limit=limit, tock=tock, real=True)
+        deeds = doist.enter(doers=[agent, serverDoer])
+
+        isalt = b"0123456789abcdef"
+        registry, issuer = helpers.createRegistry(client, agent, isalt, doist, deeds)
+        iaid = issuer["prefix"]
+        idig = issuer["state"]["d"]
+
+        rsalt = b"abcdef0123456789"
+        op = helpers.createAid(client, "recipient", rsalt)
+        recp = op["response"]["i"]
+        helpers.createEndRole(client, agent, recp, "recipient", rsalt)
+
+        dt = "2021-01-01T00:00:00.000000+00:00"
+        schema = "EFgnk_c08WmZGgv9_mpldibRuqFMTQN-rAgtD-TCOwbs"
+        creder, body, ixn = _build_issuance_body(
+            helpers,
+            registry,
+            iaid,
+            idig,
+            isalt,
+            recp,
+            "254900DA0GOGCFVWB618",
+            "2",
+            idig,
+            dt,
+            schema,
+        )
+        result = client.simulate_post(
+            path="/identifiers/issuer/credentials",
+            body=json.dumps(body).encode("utf-8"),
+        )
+        assert result.status_code == 200
+
+        while not agent.credentialer.complete(creder.said):
+            doist.recur(deeds=deeds)
+
+        res = client.simulate_get(f"/credentials/{creder.said}")
+        assert res.status_code == 200
+
+        iss_regser = eventing.issue(vcdig=creder.said, regk=registry["regk"], dt=dt)
+        regser = eventing.revoke(
+            vcdig=creder.said, regk=registry["regk"], dig=iss_regser.said, dt=dt
+        )
+        anchor = dict(i=regser.ked["i"], s=regser.ked["s"], d=regser.said)
+        serder, sigers = helpers.interact(
+            pre=iaid, bran=isalt, pidx=0, ridx=0, dig=ixn.said, sn="3", data=[anchor]
+        )
+        revoke_body = dict(rev=regser.ked, ixn=serder.ked, sigs=sigers)
+        revoke_payload = json.dumps(revoke_body).encode("utf-8")
+
+        res = client.simulate_delete(
+            path=f"/identifiers/issuer/credentials/{creder.said}",
+            body=revoke_payload,
+        )
+        assert res.status_code == 200
+
+        while not agent.registrar.complete(creder.said, sn=1):
+            doist.recur(deeds=deeds)
+
+        res = client.simulate_delete(
+            path=f"/identifiers/issuer/credentials/{creder.said}",
+            body=revoke_payload,
+        )
+        assert res.status_code == 409
+        assert "already revoked" in res.json["description"]
+
+        res = client.simulate_get(f"/credentials/{creder.said}")
+        assert res.status_code == 200
+
+        res = client.simulate_get(f"/registries/{registry['regk']}/{creder.said}")
+        assert res.status_code == 200
+        assert res.json["et"] == "rev"
+
+
+def test_group_credential_uses_durable_kel_and_tel_escrows(
+    helpers, seeder, monkeypatch
+):
+    with helpers.openKeria() as (agency, agent, app, client):
+        idResEnd = aiding.IdentifierResourceEnd()
+        _setup_credential_issue_routes(app, idResEnd)
+        seeder.seedSchema(agent.hby.db)
+
+        serverDoer = helpers.server(agency)
+        doist = doing.Doist(limit=1.0, tock=0.03125, real=True)
+        deeds = doist.enter(doers=[agent, serverDoer])
+
+        groupPre, signers = _create_group(client, helpers, doist, deeds)
+        ghab = agent.hby.habByName("group")
+        assert isinstance(ghab, SignifyGroupHab)
+
+        regser = eventing.incept(
+            groupPre,
+            baks=[],
+            toad="0",
+            nonce=Salter().qb64,
+            cnfg=[TraitCodex.NoBackers],
+            code=coring.MtrDex.Blake3_256,
+        )
+        registryAnchor = dict(i=regser.ked["i"], s=regser.ked["s"], d=regser.said)
+        registryKel, registrySigs = _group_interaction(ghab, signers, [registryAnchor])
+        registryBody = dict(
+            name="group-registry",
+            vcp=regser.ked,
+            ixn=registryKel.ked,
+            sigs=registrySigs,
+            group={},
+        )
+        result = client.simulate_post(
+            "/identifiers/group/registries", body=json.dumps(registryBody)
+        )
+        assert result.status_code == 202
+
+        for _ in range(100):
+            doist.recur(deeds=deeds)
+            if regser.pre in agent.tvy.tevers:
+                break
+        assert regser.pre in agent.tvy.tevers
+
+        counselor_starts = []
+        start = agent.counselor.start
+
+        def record_start(*args, **kwargs):
+            counselor_starts.append(kwargs["saider"].qb64)
+            return start(*args, **kwargs)
+
+        monkeypatch.setattr(agent.counselor, "start", record_start)
+
+        recipient = client.simulate_get("/identifiers/member0").json["prefix"]
+        creder = proving.credential(
+            issuer=groupPre,
+            schema="EFgnk_c08WmZGgv9_mpldibRuqFMTQN-rAgtD-TCOwbs",
+            recipient=recipient,
+            data=dict(
+                LEI="254900DA0GOGCFVWB618", dt="2021-01-01T00:00:00.000000+00:00"
+            ),
+            source={},
+            status=regser.pre,
+        )
+        iserder = eventing.issue(
+            vcdig=creder.said,
+            regk=regser.pre,
+            dt="2021-01-01T00:00:00.000000+00:00",
+        )
+        issueAnchor = dict(i=iserder.ked["i"], s=iserder.ked["s"], d=iserder.said)
+        issueKel, issueSigs = _group_interaction(ghab, signers, [issueAnchor])
+        issueBody = dict(
+            acdc=creder.sad,
+            iss=iserder.ked,
+            ixn=issueKel.ked,
+            sigs=issueSigs,
+            group={},
+        )
+        result = client.simulate_post(
+            "/identifiers/group/credentials", body=json.dumps(issueBody)
+        )
+        assert result.status_code == 202
+        issueOp = result.json
+        assert issueOp["name"] == f"credential.{creder.said}"
+        assert issueOp["metadata"]["group"]["said"] == issueKel.said
+        assert issueOp["metadata"]["tel"]["said"] == iserder.said
+
+        retry = client.simulate_post(
+            "/identifiers/group/credentials", body=json.dumps(issueBody)
+        )
+        assert retry.status_code == 202
+        assert retry.json["name"] == issueOp["name"]
+
+        for _ in range(100):
+            doist.recur(deeds=deeds)
+            if agent.credentialer.complete(creder.said):
+                break
+        assert agent.credentialer.complete(creder.said)
+        assert client.simulate_get(f"/operations/{issueOp['name']}").json["done"]
+
+        rserder = eventing.revoke(
+            vcdig=creder.said,
+            regk=regser.pre,
+            dig=iserder.said,
+            dt="2021-01-01T00:00:00.000000+00:00",
+        )
+        revokeAnchor = dict(i=rserder.ked["i"], s=rserder.ked["s"], d=rserder.said)
+        revokeKel, revokeSigs = _group_interaction(ghab, signers, [revokeAnchor])
+        revokeBody = dict(
+            rev=rserder.ked,
+            ixn=revokeKel.ked,
+            sigs=revokeSigs,
+            group={},
+        )
+        # Simulate an interrupted request after the TEL was persisted but before
+        # Registrar.revoke could enqueue its multisig escrow.
+        agent.rgy.regs[regser.pre].processEvent(serder=rserder)
+        assert credentialing._telEventSaidProcessed(
+            agent.rgy.reger, creder.said, rserder
+        )
+        assert not agent.registrar.complete(creder.said, sn=1)
+
+        result = client.simulate_delete(
+            f"/identifiers/group/credentials/{creder.said}",
+            body=json.dumps(revokeBody),
+        )
+        assert result.status_code == 202
+        revokeOp = result.json
+
+        retry = client.simulate_delete(
+            f"/identifiers/group/credentials/{creder.said}",
+            body=json.dumps(revokeBody),
+        )
+        assert retry.status_code == 202
+        assert retry.json["name"] == revokeOp["name"]
+
+        for _ in range(100):
+            doist.recur(deeds=deeds)
+            if agent.registrar.complete(creder.said, sn=1):
+                break
+        assert agent.registrar.complete(creder.said, sn=1)
+        assert client.simulate_get(f"/operations/{revokeOp['name']}").json["done"]
+        assert counselor_starts == [issueKel.said, revokeKel.said]

--- a/tests/app/test_credentialing.py
+++ b/tests/app/test_credentialing.py
@@ -315,7 +315,7 @@ def test_issue_credential(helpers, seeder):
         seeder.seedSchema(agent1.hby.db)
 
         # create the server that will receive the credential issuance messages
-        serverDoer = helpers.server(agency)
+        serverDoer = helpers.server(agency, httpPort=3903)
 
         tock = 0.03125
         limit = 1.0
@@ -689,7 +689,7 @@ def test_revoke_credential(helpers, seeder):
         seeder.seedSchema(agent.hby.db)
 
         # create the server that will receive the credential issuance messages
-        serverDoer = helpers.server(agency)
+        serverDoer = helpers.server(agency, httpPort=3904)
 
         tock = 0.03125
         limit = 1.0
@@ -1030,7 +1030,7 @@ def test_duplicate_issuance_rejection(helpers, seeder):
         _setup_credential_issue_routes(app, idResEnd)
         seeder.seedSchema(agent.hby.db)
 
-        serverDoer = helpers.server(agency)
+        serverDoer = helpers.server(agency, httpPort=3905)
         tock = 0.03125
         limit = 1.0
         doist = doing.Doist(limit=limit, tock=tock, real=True)
@@ -1090,7 +1090,7 @@ def test_issuance_rejects_stale_and_persisted_tel_events(helpers, seeder):
         _setup_credential_issue_routes(app, idResEnd)
         seeder.seedSchema(agent.hby.db)
 
-        serverDoer = helpers.server(agency)
+        serverDoer = helpers.server(agency, httpPort=3906)
         doist = doing.Doist(limit=1.0, tock=0.03125, real=True)
         deeds = doist.enter(doers=[agent, serverDoer])
 
@@ -1138,7 +1138,7 @@ def test_credential_issuance_requires_interaction_anchor(helpers, seeder):
         _setup_credential_issue_routes(app, idResEnd)
         seeder.seedSchema(agent.hby.db)
 
-        serverDoer = helpers.server(agency)
+        serverDoer = helpers.server(agency, httpPort=3907)
         doist = doing.Doist(limit=1.0, tock=0.03125, real=True)
         deeds = doist.enter(doers=[agent, serverDoer])
 
@@ -1188,7 +1188,7 @@ def test_duplicate_issuance_rejection_registry_advanced(helpers, seeder):
         _setup_credential_issue_routes(app, idResEnd)
         seeder.seedSchema(agent.hby.db)
 
-        serverDoer = helpers.server(agency)
+        serverDoer = helpers.server(agency, httpPort=3908)
         tock = 0.03125
         limit = 1.0
         doist = doing.Doist(limit=limit, tock=tock, real=True)
@@ -1272,7 +1272,7 @@ def test_duplicate_revocation_rejection(helpers, seeder):
         _setup_credential_issue_routes(app, idResEnd)
         seeder.seedSchema(agent.hby.db)
 
-        serverDoer = helpers.server(agency)
+        serverDoer = helpers.server(agency, httpPort=3909)
         tock = 0.03125
         limit = 1.0
         doist = doing.Doist(limit=limit, tock=tock, real=True)
@@ -1496,8 +1496,10 @@ def test_second_member_retry_does_not_block_in_flight_credential(helpers, seeder
         _run_until(
             doist,
             deeds,
-            lambda: agent_one.credentialer.complete(credential_two.said)
-            and agent_two.credentialer.complete(credential_two.said),
+            lambda: (
+                agent_one.credentialer.complete(credential_two.said)
+                and agent_two.credentialer.complete(credential_two.said)
+            ),
         )
 
         for client, op in (

--- a/tests/app/test_ipexing.py
+++ b/tests/app/test_ipexing.py
@@ -987,7 +987,7 @@ def test_multisig(seeder, helpers):
             path="/identifiers/issuer/credentials",
             body=json.dumps(body).encode("utf-8"),
         )
-        assert result.status == falcon.HTTP_200
+        assert result.status == falcon.HTTP_202
 
         # Submit the Credential to Agent 1
         body = dict(
@@ -1003,7 +1003,7 @@ def test_multisig(seeder, helpers):
             path="/identifiers/issuer/credentials",
             body=json.dumps(body).encode("utf-8"),
         )
-        assert result.status == falcon.HTTP_200
+        assert result.status == falcon.HTTP_202
 
         # Wait for Agent 0 to resolve the credential
         while not agent0.credentialer.complete(creder.said):
@@ -1625,7 +1625,7 @@ def test_multisig(seeder, helpers):
             body=json.dumps(body).encode("utf-8"),
         )
 
-        assert result.status == falcon.HTTP_200
+        assert result.status == falcon.HTTP_202
 
         # Submit the Revocation to Agent 1
         body = dict(
@@ -1640,7 +1640,7 @@ def test_multisig(seeder, helpers):
             body=json.dumps(body).encode("utf-8"),
         )
 
-        assert result.status == falcon.HTTP_200
+        assert result.status == falcon.HTTP_202
 
 
 def test_granter(helpers):

--- a/tests/core/test_longrunning.py
+++ b/tests/core/test_longrunning.py
@@ -331,7 +331,7 @@ def test_operation_bad_metadata(helpers):
             agent.monitor.status(credop)
         assert (
             str(err.value)
-            == "invalid long running credential operation, metadata missing 'ced' field"
+            == "invalid long running credential operation, metadata missing 'ced' or 'credential_said' field"
         )
 
         # End role

--- a/tests/core/test_longrunning.py
+++ b/tests/core/test_longrunning.py
@@ -428,6 +428,75 @@ def test_operation_bad_metadata(helpers):
         )
 
 
+def test_group_credential_operation_status(helpers, monkeypatch):
+    with helpers.openKeria() as (_, agent, _, _):
+        credential_said = "EHgwVwQT15OJvilVvW57HE4w0-GPs_Stj2OFoAHZSysY"
+        group = dict(
+            pre="EIsavDv6zpJDPauh24RSCx00jGc6VMe3l84Y8pPS8p-1",
+            sn=1,
+            said="EAF7geUfHm-M5lA-PI6Jv-4708a-KknnlMlA7U1_Wduv",
+        )
+        tel = dict(sn=0, said="EAyXphfc0qOLqEDAe0cCYCj-ovbSaEFgVgX6MrC_b5ZO")
+
+        def status(metadata):
+            return agent.monitor.status(
+                longrunning.Op(
+                    type=longrunning.OpTypes.credential,
+                    oid=credential_said,
+                    start=helping.nowIso8601(),
+                    metadata=metadata,
+                )
+            )
+
+        with pytest.raises(ValidationError) as err:
+            status(dict(credential_said=credential_said, group=dict(pre=group["pre"])))
+        assert (
+            str(err.value)
+            == "invalid long running credential operation, group metadata missing required fields ('pre', 'sn', 'said')"
+        )
+
+        with pytest.raises(ValidationError) as err:
+            status(dict(credential_said=credential_said, group=group))
+        assert (
+            str(err.value)
+            == "invalid long running credential operation, group credential metadata missing TEL sequence"
+        )
+
+        stages = dict(kel=False, tel=False, credential=False)
+        monkeypatch.setattr(agent.counselor, "complete", lambda *_: stages["kel"])
+        monkeypatch.setattr(agent.registrar, "complete", lambda **_: stages["tel"])
+        monkeypatch.setattr(
+            agent.credentialer, "complete", lambda _: stages["credential"]
+        )
+
+        metadata = dict(credential_said=credential_said, group=group, tel=tel)
+        operation = status(metadata)
+        assert operation.done is False
+        assert operation.metadata["state"] == "kel-pending"
+
+        stages["kel"] = True
+        operation = status(metadata)
+        assert operation.done is False
+        assert operation.metadata["state"] == "tel-pending"
+
+        stages["tel"] = True
+        operation = status(metadata)
+        assert operation.done is True
+        assert operation.metadata["state"] == "completed"
+        assert operation.response == dict(credential_said=credential_said)
+
+        credential_metadata = dict(ced=dict(d=credential_said), group=group, tel=tel)
+        operation = status(credential_metadata)
+        assert operation.done is False
+        assert operation.metadata["state"] == "credential-pending"
+
+        stages["credential"] = True
+        operation = status(credential_metadata)
+        assert operation.done is True
+        assert operation.metadata["state"] == "completed"
+        assert operation.response == dict(ced=credential_metadata["ced"])
+
+
 def test_error(helpers):
     with helpers.openKeria() as (agency, agent, app, client):
         opColEnd = longrunning.OperationCollectionEnd()


### PR DESCRIPTION
## Problem

A stale multisig credential-issuance acceptance could poison a member while another issuance was in flight:

1. In a 2-of-2 group, M1 issues credential 1 and M2 accepts it successfully.
2. M1 starts credential 2, leaving M2's `/multisig/iss` notification unread.
3. M2 accepts credential 1's old exchange again. The wallet creates a fresh KERIA issue request from credential 1's completed ACDC; it does **not** replay the original HTTP request, KEL, TEL, or signatures.
4. M2 then accepts credential 2.

Before this change, step 3 could return HTTP 500 and leave M2 unable to finish or read credential 2. M1 could also remain blocked waiting for M2's contribution.

Related to #213.

## Fix

Treat an already-completed group credential acceptance as idempotent by reusing its persisted operation state, without submitting a conflicting KEL or TEL event.