### PR TITLE
Handle untargeted ACDCs in IPEX Grant artifact gathering

### DIFF
--- a/src/keria/app/ipexing.py
+++ b/src/keria/app/ipexing.py
@@ -837,8 +837,8 @@ def gatherArtifacts(
 ):
     """
     Gathers a list from the local database of all dependent credential artifacts needed by the
-    recipient to fully verify an ACDC including all KEL and TEL events for the issuer and issuee and
-    any of their (delegators.
+    recipient to fully verify an ACDC, including all KEL and TEL events for the issuer, any disclosed
+    issuee, and their known delegators.
 
     Parameters:
         hby: Habery to read KELs from
@@ -851,7 +851,8 @@ def gatherArtifacts(
     """
     messages = []
     issr = creder.issuer
-    isse = creder.attrib["i"] if "i" in creder.attrib else None
+    attrib = creder.attrib
+    isse = attrib.get("i") if isinstance(attrib, dict) else None
     regk = creder.regi
 
     # Get issuer delegation parent KELs
@@ -867,9 +868,9 @@ def gatherArtifacts(
         atc = msg[serder.size :]
         messages.append((serder, atc))
 
-    # If sending to recipient that is no the issuee then
-    # Get issuee KEL and delegation parent KELs
-    if isse != recp:
+    # Include the issuee KEL and delegation parents only when the issuee is
+    # disclosed and differs from the recipient.
+    if isse is not None and isse != recp:
         ikever = hby.db.kevers[isse]
         for msg in hby.db.cloneDelegation(ikever):
             serder = serdering.SerderKERI(raw=msg)

--- a/tests/app/test_ipexing.py
+++ b/tests/app/test_ipexing.py
@@ -157,6 +157,142 @@ def test_ipex_admit(helpers, mockHelpingNowIso8601):
         }
 
 
+@pytest.mark.parametrize(
+    "compact", (False, True), ids=("expanded-untargeted", "compact-attributes")
+)
+def test_gather_artifacts_skips_issuee_kel_when_issuee_not_disclosed(helpers, compact):
+    salt = b"0123456789abcdef"
+
+    with (
+        habbing.openHab(name="issuer", salt=salt, temp=True) as (issuerHby, issuerHab),
+        helpers.withIssuer(name="issuer", hby=issuerHby) as issuer,
+    ):
+        disclosee = issuerHby.makeHab(name="disclosee")
+        creder = proving.credential(
+            issuer=issuerHab.pre,
+            schema=issuer.QVI,
+            recipient=None,
+            data={"claim": "An issuer-authored observation"},
+            source={},
+            rules={},
+        )
+
+        if compact:
+            sad = dict(creder.sad)
+            sad["d"] = ""
+            # use the digest of the ACDC above as the entire attributes "a" field
+            # for the compact ACDC variant test
+            sad["a"] = creder.attrib["d"]
+            creder = serdering.SerderACDC(sad=sad, makify=True)
+            assert isinstance(creder.attrib, str)
+        else:
+            assert "i" not in creder.attrib
+
+        # trigger happy path flows - should pull in artifact whether compact or not
+        artifacts = ipexing.gatherArtifacts(
+            issuerHby, issuer.rgy.reger, creder, disclosee.pre
+        )
+
+        assert [serder.pre for serder, _ in artifacts] == [issuerHab.pre]
+
+
+def test_gather_artifacts_skips_issuee_kel_when_recipient_is_issuee(helpers):
+    salt = b"0123456789abcdef"
+
+    with (
+        habbing.openHab(name="issuer", salt=salt, temp=True) as (issuerHby, issuerHab),
+        helpers.withIssuer(name="issuer", hby=issuerHby) as issuer,
+    ):
+        issuee = issuerHby.makeHab(name="issuee")
+        creder = proving.credential(
+            issuer=issuerHab.pre,
+            schema=issuer.QVI,
+            recipient=issuee.pre,
+            data={"claim": "An issuer-authored observation"},
+            source={},
+            rules={},
+        )
+
+        artifacts = ipexing.gatherArtifacts(
+            issuerHby, issuer.rgy.reger, creder, issuee.pre
+        )
+
+        assert [serder.pre for serder, _ in artifacts] == [issuerHab.pre]
+
+
+def test_gather_artifacts_includes_issuee_delegation_chain_for_distinct_recipient(
+    helpers,
+):
+    with helpers.openKeria() as (_, agent, _, _):
+        issuer = agent.hby.makeHab(name="issuer")
+        disclosee = agent.hby.makeHab(name="disclosee")
+        creder = proving.credential(
+            issuer=issuer.pre,
+            schema="EFgnk_c08WmZGgv9_mpldibRuqFMTQN-rAgtD-TCOwbs",
+            recipient=agent.agentHab.pre,
+            data={"claim": "An issuer-authored observation"},
+            source={},
+            rules={},
+        )
+
+        artifacts = ipexing.gatherArtifacts(
+            agent.hby, agent.rgy.reger, creder, disclosee.pre
+        )
+
+        assert [serder.pre for serder, _ in artifacts] == [
+            issuer.pre,
+            agent.caid,
+            agent.agentHab.pre,
+        ]
+
+
+def test_gather_artifacts_includes_issuer_delegation_chain_for_delegated_issuer(
+    helpers,
+):
+    with helpers.openKeria() as (_, agent, _, _):
+        disclosee = agent.hby.makeHab(name="disclosee")
+        creder = proving.credential(
+            issuer=agent.agentHab.pre,
+            schema="EFgnk_c08WmZGgv9_mpldibRuqFMTQN-rAgtD-TCOwbs",
+            recipient=None,
+            data={"claim": "An issuer-authored observation"},
+            source={},
+            rules={},
+        )
+
+        artifacts = ipexing.gatherArtifacts(
+            agent.hby, agent.rgy.reger, creder, disclosee.pre
+        )
+
+        assert [serder.pre for serder, _ in artifacts] == [
+            agent.caid,
+            agent.agentHab.pre,
+        ]
+
+
+def test_gather_artifacts_includes_registry_and_issuance_tels(helpers, seeder):
+    salt = b"0123456789abcdef"
+
+    with (
+        habbing.openHab(name="issuer", salt=salt, temp=True) as (issuerHby, issuerHab),
+        helpers.withIssuer(name="issuer", hby=issuerHby) as issuer,
+    ):
+        seeder.seedSchema(issuerHby.db)
+        issuee = issuerHby.makeHab(name="issuee")
+        issuer.createRegistry(issuerHab.pre, name="issuer")
+        credential_said = issuer.issueQVIvLEI(
+            "issuer", issuerHab, issuee.pre, "78I9GKEFM361IFY3PIN0"
+        )
+        creder, _, _, _ = issuer.rgy.reger.cloneCred(said=credential_said)
+
+        artifacts = ipexing.gatherArtifacts(
+            issuerHby, issuer.rgy.reger, creder, issuee.pre
+        )
+
+        assert creder.regi is not None
+        assert [serder.ilk for serder, _ in artifacts][-2:] == ["vcp", "iss"]
+
+
 def test_ipex_grant(helpers, mockHelpingNowIso8601, seeder):
     salt = b"0123456789abcdef"
 


### PR DESCRIPTION
Fixes #452 crash on untargeted ACDC or missing issuee

Skip issuee KEL and delegation artifact gathering when an ACDC has no disclosed issuee, including compact attribute sections. Issuer, delegated issuer/issuee, registry, and credential TEL gathering remain intact.

Adds direct unit coverage for every branch of gatherArtifacts() and verifies the existing SignifyPy untargeted-IPEX flow end to end.
