### PR TITLE
fix: make the ESSR tunnel byte-transparent

### DIFF
--- a/src/keria/core/authing.py
+++ b/src/keria/core/authing.py
@@ -259,7 +259,7 @@ class ESSRAuthenticator(Authenticator):
             raise kering.AuthNError("Signature invalid")
 
         # The real HTTP request is the plaintext of the body of the wrapper to POST /
-        environ = self.buildEnviron(agent.agentHab.decrypt(ser=cipher).decode("utf-8"))
+        environ = self.buildEnviron(agent.agentHab.decrypt(ser=cipher))
 
         # ESSR "Encrypt Sender"
         if (
@@ -288,9 +288,7 @@ class ESSRAuthenticator(Authenticator):
         response.set_header(
             "SIGNIFY-RESOURCE", agent.agentHab.pre
         )  # ESSR "Encrypt Sender"
-        inner = self.serializeResponse(
-            request.env.get("SERVER_PROTOCOL"), response
-        ).encode("utf-8")
+        inner = self.serializeResponse(request.env.get("SERVER_PROTOCOL"), response)
 
         response.status = 200
 
@@ -336,31 +334,32 @@ class ESSRAuthenticator(Authenticator):
             response.set_header(key, val)
 
     @staticmethod
-    def buildEnviron(raw: str) -> Dict[str, Any]:
-        """Deserializes a HTTP request string into an environ dict that can initialize falcon request object
+    def buildEnviron(raw: bytes) -> Dict[str, Any]:
+        """Deserializes a serialized HTTP request into an environ dict that can initialize falcon request object
+
+        The head is split from the body on the first CRLFCRLF and decoded as UTF-8. The body is
+        carried through as raw bytes so the tunnel is byte transparent.
 
         Parameters:
-            raw (str): The serialized HTTP request
+            raw (bytes): The serialized HTTP request
 
         Returns:
-            str: The serialized HTTP string
+            dict: The WSGI environ
 
         """
-        lines = raw.splitlines()
+        head, _, body = raw.partition(b"\r\n\r\n")
+        lines = head.decode("utf-8").rstrip("\r\n").split("\r\n")
 
-        method, url, protocol = lines[0].strip().split()
+        method, url, protocol = lines[0].split()
         splitUrl = urlsplit(url)
         splitHost = splitUrl.netloc.split(":")
 
         headers = {}
-        i = 1
-        while i < len(lines) and lines[i].strip() != "":
-            header_line = lines[i].strip()
-            header_name, header_value = header_line.split(":", 1)
-            headers[header_name.strip()] = header_value.strip()
-            i += 1
-
-        body = "\n".join(lines[i + 1 :]).strip().encode("utf-8")
+        for line in lines[1:]:
+            name, sep, value = line.partition(":")
+            if not sep:
+                raise ValueError(f"Invalid header line {line}")
+            headers[name.strip().lower()] = value.strip()
 
         environ = {
             "wsgi.input": BytesIO(body),
@@ -375,7 +374,7 @@ class ESSRAuthenticator(Authenticator):
             "PATH_INFO": splitUrl.path,
             "QUERY_STRING": splitUrl.query,
             "CONTENT_TYPE": headers.get("content-type", ""),
-            "CONTENT_LENGTH": str(len(body)) if body else "0",
+            "CONTENT_LENGTH": str(len(body)),
         }
 
         for key, value in headers.items():
@@ -385,34 +384,30 @@ class ESSRAuthenticator(Authenticator):
         return environ
 
     @staticmethod
-    def serializeResponse(protocol: str, response: falcon.Response) -> str:
-        """Serializes a falcon response object into a HTTP string
+    def serializeResponse(protocol: str, response: falcon.Response) -> bytes:
+        """Serializes a falcon response object into a serialized HTTP response
 
         Parameters:
             protocol (str): HTTP protocol string
             response (falcon.Response): Falcon response object
 
         Returns:
-            str: The serialized HTTP string
+            bytes: The serialized HTTP response
 
         """
-        status_line = f"{protocol} {response.status}"
-        headers = "\r\n".join(
-            [
-                f"{key}: {value}"
-                for key, value in response.headers.items()
-                if key.lower() not in CORS_HEADERS
-            ]
+        # rendering can set content-type, so it has to happen before the head is built
+        body = response.render_body() or b""
+
+        lines = [f"{protocol} {response.status}"]
+        lines.extend(
+            f"{key}: {value}"
+            for key, value in response.headers.items()
+            if key.lower() not in CORS_HEADERS
         )
 
-        if response.text:
-            body = response.text
-        elif response.data:
-            body = response.data.decode("utf-8")
-        else:
-            body = ""
+        head = "\r\n".join(lines).encode("utf-8")
 
-        return f"{status_line}\r\n{headers}\r\n\r\n{body}"
+        return head + b"\r\n\r\n" + body
 
 
 class AuthenticationMiddleware:

--- a/src/keria/core/authing.py
+++ b/src/keria/core/authing.py
@@ -259,7 +259,10 @@ class ESSRAuthenticator(Authenticator):
             raise kering.AuthNError("Signature invalid")
 
         # The real HTTP request is the plaintext of the body of the wrapper to POST /
-        environ = self.buildEnviron(agent.agentHab.decrypt(ser=cipher))
+        try:
+            environ = self.buildEnviron(agent.agentHab.decrypt(ser=cipher))
+        except ValueError as ex:  # includes UnicodeDecodeError on a non UTF-8 head
+            raise kering.AuthNError(f"Invalid ESSR payload: {ex}")
 
         # ESSR "Encrypt Sender"
         if (
@@ -348,7 +351,7 @@ class ESSRAuthenticator(Authenticator):
 
         """
         head, _, body = raw.partition(b"\r\n\r\n")
-        lines = head.decode("utf-8").rstrip("\r\n").split("\r\n")
+        lines = head.decode("utf-8").split("\r\n")
 
         method, url, protocol = lines[0].split()
         splitUrl = urlsplit(url)

--- a/src/keria/core/authing.py
+++ b/src/keria/core/authing.py
@@ -259,10 +259,7 @@ class ESSRAuthenticator(Authenticator):
             raise kering.AuthNError("Signature invalid")
 
         # The real HTTP request is the plaintext of the body of the wrapper to POST /
-        try:
-            environ = self.buildEnviron(agent.agentHab.decrypt(ser=cipher))
-        except ValueError as ex:  # includes UnicodeDecodeError on a non UTF-8 head
-            raise kering.AuthNError(f"Invalid ESSR payload: {ex}")
+        environ = self.buildEnviron(agent.agentHab.decrypt(ser=cipher))
 
         # ESSR "Encrypt Sender"
         if (
@@ -454,7 +451,7 @@ class AuthenticationMiddleware:
         try:
             authenticator.inbound(req)
             return
-        except (kering.AuthNError, ValueError):
+        except (kering.AuthNError, ValueError, UnicodeDecodeError):
             pass
 
         rep.complete = (

--- a/tests/core/test_authing.py
+++ b/tests/core/test_authing.py
@@ -496,6 +496,23 @@ signify-resource: EDqDrGuzned0HOKFTLqd7m7O7WGE5zYIOHrlCq4EnWxy\r
             + body
         )
 
+        middleware = authing.AuthenticationMiddleware(
+            agency=agency, authn=None, essrAuthn=authn
+        )
+        for malformed in (
+            b"GET http://127.0.0.1:3901/contacts\r\n\r\n",
+            b"GET http://127.0.0.1:3901/contacts HTTP/1.1\r\nnot-a-header\r\n\r\n",
+            b"\xff\xfe\r\n\r\n",
+        ):
+            with pytest.raises(kering.AuthNError) as e:
+                authn.inbound(sealed(malformed))
+            assert str(e.value).startswith("Invalid ESSR payload")
+
+            rep = falcon.Response()
+            middleware.process_request(sealed(malformed), rep)
+            assert rep.complete is True
+            assert rep.status == falcon.HTTP_401
+
 
 RESOURCE = "ECjmyrSFFfOb3VJi1JUKTy-Vn766h-VKl3XY8OEFdxBF"
 
@@ -616,11 +633,10 @@ def test_build_environ_header_names_are_case_insensitive():
 
 
 def test_build_environ_malformed():
-    environ = authing.ESSRAuthenticator.buildEnviron(
-        b"GET http://127.0.0.1/main HTTP/1.1\r\n"
-    )
-    assert environ["CONTENT_LENGTH"] == "0"
-    assert environ["wsgi.input"].read() == b""
+    with pytest.raises(ValueError):  # head not terminated by CRLFCRLF
+        authing.ESSRAuthenticator.buildEnviron(
+            b"GET http://127.0.0.1/main HTTP/1.1\r\n"
+        )
 
     with pytest.raises(ValueError):
         authing.ESSRAuthenticator.buildEnviron(b"GET http://127.0.0.1/main\r\n\r\n")

--- a/tests/core/test_authing.py
+++ b/tests/core/test_authing.py
@@ -28,6 +28,11 @@ def create_req(**kwargs):
     return authing.ModifiableRequest(testing.create_environ(**kwargs))
 
 
+def essr_request(requestLine, headers=(), body=b""):
+    head = "\r\n".join([requestLine, *(f"{name}: {value}" for name, value in headers)])
+    return head.encode("utf-8") + b"\r\n\r\n" + body
+
+
 def test_signed_header_authenticator(mockHelpingNowUTC):
     salt = b"1111456789abcdef"
     salter = core.Salter(raw=salt)
@@ -211,11 +216,16 @@ def test_essr_authenticator(mockHelpingNowUTC):
         assert str(e.value) == "Request should not expose endpoint in the clear"
 
         dt = "2022-09-24T00:05:48.196795+00:00"
-        http = """GET http://127.0.0.1:3901/identifiers/aid1?x=y HTTP/1.1
-content-type: application/json
-signify-resource: ECjmyrSFFfOb3VJi1JUKTy-Vn766h-VKl3XY8OEFdxBF
-
-""".encode("utf-8")
+        http = essr_request(
+            "GET http://127.0.0.1:3901/identifiers/aid1?x=y HTTP/1.1",
+            [
+                ("content-type", "application/json"),
+                (
+                    "signify-resource",
+                    "ECjmyrSFFfOb3VJi1JUKTy-Vn766h-VKl3XY8OEFdxBF",
+                ),
+            ],
+        )
         pubkey = pysodium.crypto_sign_pk_to_box_pk(agent.agentHab.kever.verfers[0].raw)
         raw = pysodium.crypto_box_seal(http, pubkey)
 
@@ -310,11 +320,13 @@ signify-resource: ECjmyrSFFfOb3VJi1JUKTy-Vn766h-VKl3XY8OEFdxBF
 
         # Finally correct ESSR
         dt = "2022-09-24T00:05:48.196795+00:00"
-        http = f"""GET http://127.0.0.1:3901/identifiers/aid1?x=y HTTP/1.1
-        content-type: application/json
-        signify-resource: {controller.pre}
-
-        """.encode("utf-8")
+        http = essr_request(
+            "GET http://127.0.0.1:3901/identifiers/aid1?x=y HTTP/1.1",
+            [
+                ("Content-Type", "application/json"),  # liberal on header name case
+                ("signify-resource", controller.pre),
+            ],
+        )
         pubkey = pysodium.crypto_sign_pk_to_box_pk(agent.agentHab.kever.verfers[0].raw)
         raw = pysodium.crypto_box_seal(http, pubkey)
 
@@ -420,19 +432,85 @@ signify-resource: EDqDrGuzned0HOKFTLqd7m7O7WGE5zYIOHrlCq4EnWxy\r
 """
         )
 
+        def sealed(http):
+            raw = pysodium.crypto_box_seal(http, pubkey)
+            payload = dict(
+                src=controller.pre,
+                dest=agent.pre,
+                d=coring.Diger(ser=raw, code=MtrDex.Blake3_256).qb64,
+                dt=dt,
+            )
+            sig = controller.sign(
+                json.dumps(payload, separators=(",", ":")).encode("utf-8"),
+                indexed=False,
+            )
+            return create_req(
+                method="POST",
+                path="/",
+                body=raw,
+                headers={
+                    "SIGNATURE": ending.signature(
+                        [
+                            ending.Signage(
+                                markers=dict(signify=sig[0]),
+                                indexed=False,
+                                signer=None,
+                                ordinal=None,
+                                digest=None,
+                                kind=None,
+                            )
+                        ]
+                    )["Signature"],
+                    "SIGNIFY-TIMESTAMP": dt,
+                    "SIGNIFY-RESOURCE": controller.pre,
+                    "SIGNIFY-RECEIVER": agent.pre,
+                },
+            )
+
+        # Nothing in the tunnel is normalized, stripped or re-encoded in either direction
+        body = json.dumps({"alias": "a\u2028b\u2029c\u0085d\r\ne "}).encode("utf-8")
+        req = sealed(
+            essr_request(
+                "POST http://127.0.0.1:3901/contacts HTTP/1.1",
+                [
+                    ("content-type", "application/json"),
+                    ("signify-resource", controller.pre),
+                ],
+                body,
+            )
+        )
+
+        authn.inbound(req)
+        assert req.path == "/contacts"
+        assert req.content_length == len(body)
+        assert req.bounded_stream.read() == body
+
+        rep = falcon.Response()
+        rep.status = "200 OK"
+        rep.data = body
+        authn.outbound(req, rep)
+        assert controller.decrypt(ser=rep.data) == (
+            b"HTTP/1.1 200 OK\r\nsignify-resource: "
+            + agent.agentHab.pre.encode("utf-8")
+            + b"\r\n\r\n"
+            + body
+        )
+
+
+RESOURCE = "ECjmyrSFFfOb3VJi1JUKTy-Vn766h-VKl3XY8OEFdxBF"
+
 
 def test_build_environ():
-    http = """GET http://127.0.0.1:3901/identifiers/aid1?x=y HTTP/1.1
-    content-type: application/json
-    signify-resource: ECjmyrSFFfOb3VJi1JUKTy-Vn766h-VKl3XY8OEFdxBF
-
-    """
+    http = essr_request(
+        "GET http://127.0.0.1:3901/identifiers/aid1?x=y HTTP/1.1",
+        [("content-type", "application/json"), ("signify-resource", RESOURCE)],
+    )
     environ = authing.ESSRAuthenticator.buildEnviron(http)
     assert environ == {
         "CONTENT_LENGTH": "0",
         "CONTENT_TYPE": "application/json",
         "HTTP_CONTENT_TYPE": "application/json",
-        "HTTP_SIGNIFY_RESOURCE": "ECjmyrSFFfOb3VJi1JUKTy-Vn766h-VKl3XY8OEFdxBF",
+        "HTTP_SIGNIFY_RESOURCE": RESOURCE,
         "PATH_INFO": "/identifiers/aid1",
         "QUERY_STRING": "x=y",
         "REQUEST_METHOD": "GET",
@@ -443,18 +521,18 @@ def test_build_environ():
         "wsgi.input": mock.ANY,
         "wsgi.url_scheme": "http",
     }
+    assert environ["wsgi.input"].read() == b""
 
-    http = """POST http://127.0.0.1/ HTTP/1.0
-    content-type: text/plain
-    signify-resource: ECjmyrSFFfOb3VJi1JUKTy-Vn766h-VKl3XY8OEFdxBF
-
-    """
+    http = essr_request(
+        "POST http://127.0.0.1/ HTTP/1.0",
+        [("content-type", "text/plain"), ("signify-resource", RESOURCE)],
+    )
     environ = authing.ESSRAuthenticator.buildEnviron(http)
     assert environ == {
         "CONTENT_LENGTH": "0",
         "CONTENT_TYPE": "text/plain",
         "HTTP_CONTENT_TYPE": "text/plain",
-        "HTTP_SIGNIFY_RESOURCE": "ECjmyrSFFfOb3VJi1JUKTy-Vn766h-VKl3XY8OEFdxBF",
+        "HTTP_SIGNIFY_RESOURCE": RESOURCE,
         "PATH_INFO": "/",
         "QUERY_STRING": "",
         "REQUEST_METHOD": "POST",
@@ -466,18 +544,17 @@ def test_build_environ():
         "wsgi.url_scheme": "http",
     }
 
-    http = """POST https://127.0.0.1/main HTTP/1.1
-    content-type: application/json
-    signify-resource: ECjmyrSFFfOb3VJi1JUKTy-Vn766h-VKl3XY8OEFdxBF
-
-    {}
-    """
+    http = essr_request(
+        "POST https://127.0.0.1/main HTTP/1.1",
+        [("content-type", "application/json"), ("signify-resource", RESOURCE)],
+        b"{}",
+    )
     environ = authing.ESSRAuthenticator.buildEnviron(http)
     assert environ == {
         "CONTENT_LENGTH": "2",
         "CONTENT_TYPE": "application/json",
         "HTTP_CONTENT_TYPE": "application/json",
-        "HTTP_SIGNIFY_RESOURCE": "ECjmyrSFFfOb3VJi1JUKTy-Vn766h-VKl3XY8OEFdxBF",
+        "HTTP_SIGNIFY_RESOURCE": RESOURCE,
         "PATH_INFO": "/main",
         "QUERY_STRING": "",
         "REQUEST_METHOD": "POST",
@@ -488,29 +565,73 @@ def test_build_environ():
         "wsgi.input": mock.ANY,
         "wsgi.url_scheme": "https",
     }
+    assert environ["wsgi.input"].read() == b"{}"
 
-    http = """POST https://127.0.0.1/main HTTP/1.1
-    content-type: application/json
-    signify-resource: ECjmyrSFFfOb3VJi1JUKTy-Vn766h-VKl3XY8OEFdxBF
-
-    ññ
-    """
+    http = essr_request(
+        "POST https://127.0.0.1/main HTTP/1.1",
+        [("content-type", "application/json"), ("signify-resource", RESOURCE)],
+        "ññ".encode("utf-8"),
+    )
     environ = authing.ESSRAuthenticator.buildEnviron(http)
-    assert environ == {
-        "CONTENT_LENGTH": "4",  # ñ takes 2
-        "CONTENT_TYPE": "application/json",
-        "HTTP_CONTENT_TYPE": "application/json",
-        "HTTP_SIGNIFY_RESOURCE": "ECjmyrSFFfOb3VJi1JUKTy-Vn766h-VKl3XY8OEFdxBF",
-        "PATH_INFO": "/main",
-        "QUERY_STRING": "",
-        "REQUEST_METHOD": "POST",
-        "SERVER_NAME": "127.0.0.1",
-        "SERVER_PORT": "433",
-        "SERVER_PROTOCOL": "HTTP/1.1",
-        "wsgi.errors": mock.ANY,
-        "wsgi.input": mock.ANY,
-        "wsgi.url_scheme": "https",
-    }
+    assert environ["CONTENT_LENGTH"] == "4"  # ñ takes 2
+    assert environ["wsgi.input"].read() == "ññ".encode("utf-8")
+
+
+def test_build_environ_body_is_verbatim():
+    def body_of(body):
+        environ = authing.ESSRAuthenticator.buildEnviron(
+            essr_request(
+                "POST http://127.0.0.1/main HTTP/1.1",
+                [("content-type", "application/json")],
+                body,
+            )
+        )
+        assert environ["CONTENT_LENGTH"] == str(len(body))
+        return environ["wsgi.input"].read()
+
+    # the hazard class that made the client escape these before sealing
+    hazards = json.dumps({"alias": "a\u2028b\u2029c\u0085d"}).encode("utf-8")
+    assert body_of(hazards) == hazards
+
+    assert body_of(b'{"a": "x\r\ny"}') == b'{"a": "x\r\ny"}'
+    assert body_of(b"one\r\n\r\ntwo") == b"one\r\n\r\ntwo"
+    assert body_of(b"  padded  \n") == b"  padded  \n"
+    assert body_of(b"\xff\xfe\x00binary") == b"\xff\xfe\x00binary"
+
+
+def test_build_environ_header_names_are_case_insensitive():
+    http = essr_request(
+        "POST http://127.0.0.1/main HTTP/1.1",
+        [
+            ("Content-Type", "application/json"),
+            ("Signify-Resource", RESOURCE),
+            ("Location", "http://example.com: 8080"),
+        ],
+    )
+    environ = authing.ESSRAuthenticator.buildEnviron(http)
+    assert environ["CONTENT_TYPE"] == "application/json"
+    assert environ["HTTP_CONTENT_TYPE"] == "application/json"
+    assert environ["HTTP_SIGNIFY_RESOURCE"] == RESOURCE
+    assert environ["HTTP_LOCATION"] == "http://example.com: 8080"
+
+
+def test_build_environ_malformed():
+    environ = authing.ESSRAuthenticator.buildEnviron(
+        b"GET http://127.0.0.1/main HTTP/1.1\r\n"
+    )
+    assert environ["CONTENT_LENGTH"] == "0"
+    assert environ["wsgi.input"].read() == b""
+
+    with pytest.raises(ValueError):
+        authing.ESSRAuthenticator.buildEnviron(b"GET http://127.0.0.1/main\r\n\r\n")
+
+    with pytest.raises(ValueError):
+        authing.ESSRAuthenticator.buildEnviron(
+            b"GET http://127.0.0.1/main HTTP/1.1\r\nnot-a-header\r\n\r\n"
+        )
+
+    with pytest.raises(UnicodeDecodeError):
+        authing.ESSRAuthenticator.buildEnviron(b"\xff\xfe\r\n\r\n")
 
 
 def test_serialize_response():
@@ -528,33 +649,43 @@ def test_serialize_response():
     rep.status = "400 Bad Request"
 
     serialized = authing.ESSRAuthenticator.serializeResponse("HTTP/1.1", rep)
-    assert (
-        serialized
-        == """HTTP/1.1 400 Bad Request\r
-signify-resource: EDqDrGuzned0HOKFTLqd7m7O7WGE5zYIOHrlCq4EnWxy\r
-\r
-"""
+    assert serialized == (
+        b"HTTP/1.1 400 Bad Request\r\n"
+        b"signify-resource: EDqDrGuzned0HOKFTLqd7m7O7WGE5zYIOHrlCq4EnWxy\r\n"
+        b"\r\n"
     )
 
     rep.data = json.dumps({"a": "b"}).encode("utf-8")
     serialized = authing.ESSRAuthenticator.serializeResponse("HTTP/1.1", rep)
-    assert (
-        serialized
-        == """HTTP/1.1 400 Bad Request\r
-signify-resource: EDqDrGuzned0HOKFTLqd7m7O7WGE5zYIOHrlCq4EnWxy\r
-\r
-{"a": "b"}"""
+    assert serialized == (
+        b"HTTP/1.1 400 Bad Request\r\n"
+        b"signify-resource: EDqDrGuzned0HOKFTLqd7m7O7WGE5zYIOHrlCq4EnWxy\r\n"
+        b"\r\n"
+        b'{"a": "b"}'
     )
 
     rep.data = None
     rep.text = "Identifier not found!"
     serialized = authing.ESSRAuthenticator.serializeResponse("HTTP/1.1", rep)
+    assert serialized == (
+        b"HTTP/1.1 400 Bad Request\r\n"
+        b"signify-resource: EDqDrGuzned0HOKFTLqd7m7O7WGE5zYIOHrlCq4EnWxy\r\n"
+        b"\r\n"
+        b"Identifier not found!"
+    )
+
+
+def test_serialize_response_without_headers():
+    rep = falcon.Response()
+    rep.status = "204 No Content"
     assert (
-        serialized
-        == """HTTP/1.1 400 Bad Request\r
-signify-resource: EDqDrGuzned0HOKFTLqd7m7O7WGE5zYIOHrlCq4EnWxy\r
-\r
-Identifier not found!"""
+        authing.ESSRAuthenticator.serializeResponse("HTTP/1.1", rep)
+        == b"HTTP/1.1 204 No Content\r\n\r\n"
+    )
+
+    rep.data = b"\xff\xfe\x00binary"
+    assert authing.ESSRAuthenticator.serializeResponse("HTTP/1.1", rep) == (
+        b"HTTP/1.1 204 No Content\r\n\r\n\xff\xfe\x00binary"
     )
 
 

--- a/tests/core/test_authing.py
+++ b/tests/core/test_authing.py
@@ -504,10 +504,6 @@ signify-resource: EDqDrGuzned0HOKFTLqd7m7O7WGE5zYIOHrlCq4EnWxy\r
             b"GET http://127.0.0.1:3901/contacts HTTP/1.1\r\nnot-a-header\r\n\r\n",
             b"\xff\xfe\r\n\r\n",
         ):
-            with pytest.raises(kering.AuthNError) as e:
-                authn.inbound(sealed(malformed))
-            assert str(e.value).startswith("Invalid ESSR payload")
-
             rep = falcon.Response()
             middleware.process_request(sealed(malformed), rep)
             assert rep.complete is True
@@ -797,6 +793,19 @@ def test_authentication_middleware(mockHelpingNowUTC):
 
     mockESSRAuthN.reset_mock()
     mockESSRAuthN.inbound.side_effect = ValueError()
+
+    req = create_req(method="POST", path="/")
+    rep = falcon.Response()
+
+    vc.process_request(req, rep)
+    mockESSRAuthN.inbound.assert_called_once()
+    assert rep.complete is True
+    assert rep.status == falcon.HTTP_401
+
+    mockESSRAuthN.reset_mock()
+    mockESSRAuthN.inbound.side_effect = UnicodeDecodeError(
+        "utf-8", b"\xff", 0, 1, "invalid start byte"
+    )
 
     req = create_req(method="POST", path="/")
     rep = falcon.Response()


### PR DESCRIPTION
The ESSR tunnel round-tripped bodies through text, corrupting unusual line separators, whitespace, and binary payloads.
